### PR TITLE
Devel

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,4 +1,15 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+
+# This workflow combines elements of check-standard.yaml and
+# check-no-suggests.yaml to check if the package functions correctly without the
+# dependencies listed in 'Suggests' which I use for documentation.
+
+# NOTE: This workflow only directly installs "hard" dependencies, i.e. Depends,
+# Imports, and LinkingTo dependencies. Notably, Suggests dependencies are never
+# installed, with the exception of testthat, knitr, and rmarkdown. The cache is
+# never used to avoid accidentally restoring a cache containing a suggested
+# dependency.
+
 # Modifications:
 # - not run GHA on 'push': it should be sufficient to run R CMD check locally
 #   before pushing and run GHA on pull requests.
@@ -6,8 +17,11 @@
 # - enable manually triggering GHA: added 'workflow_dispatch:' at 'on:' (see
 #   https://docs.github.com/en/actions/reference/workflows-and-actions and
 #   https://docs.github.com/en/actions/how-tos/manage-workflow-runs).
-# - run GHA with R version 4.1.0 (miniimum version required by dependency
-#   checkinput) for macos, windows, and ubuntu.
+# - run GHA with the currently released version of R and R version 4.1.0 (the
+#   minimum R version required by dependency checkinput) on macOS, Windows, and
+#   Ubuntu. In addition, run GHA with the devel-version of R on Ubuntu.
+# - allow 'tinytest' instead of 'testthat' because that is the package I use for
+#   the tests.
 
 # Need help debugging build failures? Start at
 # https://github.com/r-lib/actions#where-to-find-help
@@ -57,7 +71,13 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
+          dependencies: '"hard"'
+          cache: false
+          extra-packages: |
+            any::rcmdcheck
+            any::tinytest
+            any::knitr
+            any::rmarkdown
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
 ### Miscellaneous
 - Make the location of newlines more predictable by hardcoding newlines using
  `\n` instead of using `wrap_text()` in warnings.
+- Combine elements of workflows check-standard.yaml and check-no-suggests.yaml to
+  check if the package functions correctly without the dependencies listed in
+  'Suggests' which I use for documentation.
 
 
 # progutils 0.0.6

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# devel
+
+### Miscellaneous
+- Make the location of newlines more predictable by hardcoding newlines using
+ `\n` instead of using `wrap_text()` in warnings.
+
+
 # progutils 0.0.6
 
 ### Breaking changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,13 +1,3 @@
-# devel
-
-### Miscellaneous
-- Make the location of newlines more predictable by hardcoding newlines using
- `\n` instead of using `wrap_text()` in warnings.
-- Combine elements of workflows check-standard.yaml and check-no-suggests.yaml to
-  check if the package functions correctly without the dependencies listed in
-  'Suggests' which I use for documentation.
-
-
 # progutils 0.0.6
 
 ### Breaking changes
@@ -21,6 +11,11 @@
 - `check_case()` and `replace_vals()`: outcomment failing tests that seem to
   fail on sort order for uppercase vs. lowercase characters (differences caused
   by locale settings (see `Sys.getlocale()`)?
+- Make the location of newlines more predictable by hardcoding newlines using
+ `\n` instead of using `wrap_text()` in warnings.
+- Combine elements of workflows `check-standard.yaml` and `check-no-suggests.yaml`
+  to check if the package functions correctly without the dependencies listed in
+  'Suggests' which I use for documentation.
 
 
 # progutils 0.0.5

--- a/R/check_os_is_windows.R
+++ b/R/check_os_is_windows.R
@@ -15,10 +15,9 @@ check_os_is_windows <- function(action = c("warn", "message", "quiet")) {
     OS_is_Windows <- TRUE
   } else {
     OS_is_Windows <- FALSE
-    text_msg <- wrap_text(paste0(
-      "This function might fail because it is meant to be used on Windows,",
-      " whereas you are using ", .Platform$OS.type, ": ", utils::osVersion, "."))
-
+    text_msg <- paste0("This function might fail because it is meant to be",
+                       " used on Windows, whereas you\nare using ",
+                       .Platform$OS.type, ": ", utils::osVersion, ".")
     signal_text(text = text_msg, signal = action)
   }
   invisible(OS_is_Windows)

--- a/R/create_path.R
+++ b/R/create_path.R
@@ -99,8 +99,7 @@ create_path <- function(filename, format_stamp = "%Y_%m_%d_%H_%M_%S",
   # See the 'Programming note' why not using tools::file_path_sans_ext()
   file_sans_ext <- progutils::file_path_sans_ext(filename)
   if(file_ext == "" || file_sans_ext == "" || filename == file_sans_ext) {
-    stop(wrap_text(paste0(
-      "'filename' should include the name and the file extension: ", filename)))
+    stop("'filename' should include the name and the file extension:\n", filename)
   }
 
   if(format_stamp != "") {

--- a/R/get_filename.R
+++ b/R/get_filename.R
@@ -88,12 +88,10 @@ get_filename <- function(dir = ".", pattern, ignore_case = TRUE, quietly = FALSE
 
   msg_match <- paste0(
     "case-", if(ignore_case) {"in"}, "sensitive matches to pattern '",
-    pattern, "' are present in directory '", dir, "'")
+    pattern, "' are present in directory\n'", dir, "'")
 
   if(length(files_present) > 1L) {
-    stop(wrap_text(x = paste0(
-      "Multiple ", msg_match, ": ", paste_quoted(files_present), "!"
-    )))
+    stop(paste0("Multiple ", msg_match, ": ", paste_quoted(files_present), "!"))
   }
 
   if(length(files_present) == 0L) {
@@ -104,22 +102,22 @@ get_filename <- function(dir = ".", pattern, ignore_case = TRUE, quietly = FALSE
 
       if(length(match_case_insensitive) == 0L) {
         msg_match <- paste0(
-          msg_match, ". No case-insensitive match is present either")
+          msg_match, ".\nNo case-insensitive match is present either")
       } else {
         if(length(match_case_insensitive) == 1L) {
           msg_match <- paste0(
             msg_match,
-            ". However, a case-insensitive match to 'pattern' is present: ",
+            ".\nHowever, a case-insensitive match to 'pattern' is present: ",
             paste_quoted(match_case_insensitive))
         } else {
           msg_match <- paste0(
             msg_match,
-            ". However, case-insensitive matches to 'pattern' are present: ",
+            ".\nHowever, case-insensitive matches to 'pattern' are present: ",
             paste_quoted(match_case_insensitive))
         }
       }
     }
-    stop(wrap_text(x = paste0("No ", msg_match, ".")))
+    stop("No ", msg_match, ".")
   }
 
   if(!quietly) {

--- a/R/reorder_cols.R
+++ b/R/reorder_cols.R
@@ -57,9 +57,8 @@ reorder_cols <- function(x, new_order) {
 
   bool_order_in_names <- new_order %in% colnames(x)
   if(any(!bool_order_in_names)) {
-    warning(wrap_text(paste0(
-      "Dropped values of 'new_order' that are not present in column names of 'x': ",
-      paste_quoted(new_order[!bool_order_in_names]))))
+    warning("Dropped values of 'new_order' that are not present in column",
+            " names of 'x':\n", paste_quoted(new_order[!bool_order_in_names]))
   }
 
   x[, new_order[bool_order_in_names], drop = FALSE]

--- a/R/reorder_levels.R
+++ b/R/reorder_levels.R
@@ -69,16 +69,12 @@ reorder_levels <- function(x, new_order, warn_drop_order = TRUE) {
     # present in its levels
     x <- x_dropped
     if(length(dropped_levels) > 0L) {
-      warning(wrap_text(x = paste0(
-        "Dropped levels of 'x' that are not present in its values: ",
-        paste_quoted(dropped_levels)
-      )))
+      warning("Dropped levels of 'x' that are not present in its values:\n",
+              paste_quoted(dropped_levels))
     }
     if(length(added_levels) > 0L) {
-      warning(wrap_text(x = paste0(
-        "Added values of 'x' that were not present in its levels to its levels: ",
-        paste_quoted(added_levels)
-      )))
+      warning("Added missing levels for values of 'x':\n",
+              paste_quoted(added_levels))
     }
   }
 
@@ -86,16 +82,14 @@ reorder_levels <- function(x, new_order, warn_drop_order = TRUE) {
   if(any(!bool_levels_in_new_order)) {
     levels_appended <- levels(x)[!bool_levels_in_new_order]
     new_order <- c(new_order, levels_appended)
-    warning(wrap_text(paste0(
-      "Appended levels of 'x' that were not present in 'new_order' to 'new_order': ",
-      paste_quoted(levels_appended))))
+    warning("Appended levels of 'x' that were not present in 'new_order' to",
+            " 'new_order':\n", paste_quoted(levels_appended))
   }
 
   bool_order_in_levels <- new_order %in% levels(x)
   if(warn_drop_order && any(!bool_order_in_levels)) {
-    warning(wrap_text(paste0(
-      "Dropped values of 'new_order' that are not present in 'x': ",
-      paste_quoted(new_order[!bool_order_in_levels]))))
+    warning("Dropped values of 'new_order' that are not present in 'x':\n",
+            paste_quoted(new_order[!bool_order_in_levels]))
   }
   factor(x, levels = new_order[bool_order_in_levels], exclude = NULL)
 }

--- a/R/vect_to_char.R
+++ b/R/vect_to_char.R
@@ -84,8 +84,7 @@ vect_to_char <- function(x, signif = 3L, width = Inf, sep = ": ",
     x <- paste0(class(x), "(0)")
   }
 
-  if(checkinput::all_characters(x = names(x), allow_empty = TRUE,
-                                allow_zero = TRUE, allow_NA = TRUE)) {
+  if(!is.null(names(x))) {
     x <- paste(names(x), x, sep = sep, collapse = collapse)
   } else {
     x <- paste(x, collapse = collapse)

--- a/R/wrap_text.R
+++ b/R/wrap_text.R
@@ -38,6 +38,13 @@
 #' argument `width` in [strwrap()] indicates the width *at* which text should be
 #' wrapped.
 #'
+#' @section Programming notes:
+#' Using `wrap_text()` on `x` of variable length, e.g., in the text of warnings
+#' that report a file path or a user-provided variable name, makes the location
+#' of newlines unpredictable and thus difficult to test reliably. To circumvent
+#' this, put the constant part in the front of the message and hardcode newlines
+#' using `\n`.
+#'
 #' @seealso [cat()] [paste()] [strwrap()] `bbmle:::strwrapx()`
 #'
 #' @family functions to modify character vectors

--- a/inst/tinytest/test_create_path.R
+++ b/inst/tinytest/test_create_path.R
@@ -212,7 +212,7 @@ expect_error(create_path(filename = "", dir = my_tempdir),
 for(filenm_in in c("abcd", "abc.", "ab.c#", ".", ".txt", ".html")) {
   expect_error(create_path(filename = filenm_in, dir = my_tempdir),
                pattern = paste0("'filename' should include the name and the",
-                                " file extension: ", filenm_in),
+                                " file extension:\n", filenm_in),
                fixed = FALSE)
 }
 

--- a/inst/tinytest/test_reorder_cols.R
+++ b/inst/tinytest/test_reorder_cols.R
@@ -33,7 +33,7 @@ expect_warning(
   expect_identical(reorder_cols(x = test_df, new_order = c("b", "a", "d")),
                    output_df),
   pattern = paste0("Dropped values of 'new_order' that are not present in",
-                   " column names of 'x': 'd'"),
+                   " column names of 'x':\n'd'"),
   strict = TRUE, fixed = TRUE)
 
 
@@ -98,7 +98,7 @@ expect_warning(
   expect_identical(reorder_cols(x = test_df, new_order = new_order_weird),
                    output_df),
   pattern = paste0("Dropped values of 'new_order' that are not present in",
-                   " column names of 'x': '',\n'NA', 'd'"),
+                   " column names of 'x':\n'', 'NA', 'd'"),
   strict = TRUE, fixed = TRUE)
 
 # Weird input to 'new_order', matrix input to 'x'.
@@ -113,7 +113,7 @@ expect_warning(
   expect_identical(reorder_cols(x = test_mat, new_order = new_order_weird),
                    output_mat),
   pattern = paste0("Dropped values of 'new_order' that are not present in",
-                   " column names of 'x': '',\n'NA', 'd'"),
+                   " column names of 'x':\n'', 'NA', 'd'"),
   strict = TRUE, fixed = TRUE)
 
 # Factor input to 'new_order'

--- a/inst/tinytest/test_reorder_levels.R
+++ b/inst/tinytest/test_reorder_levels.R
@@ -21,9 +21,9 @@ factor_order <- factor(x = new_order, levels = new_order[3:1])
 vals_NA <- c(vals[1:3], NA, vals[2:1])
 
 warn_append_levels <- paste0("Appended levels of 'x' that were not present in",
-                             " 'new_order' to 'new_order': ")
-warn_drop_levels <- "Dropped levels of 'x' that are not present in its values: "
-warn_drop_order <- "Dropped values of 'new_order' that are not present in 'x': "
+                             " 'new_order' to 'new_order':\n")
+warn_drop_levels <- "Dropped levels of 'x' that are not present in its values:\n"
+warn_drop_order <- "Dropped values of 'new_order' that are not present in 'x':\n"
 warn_missing_levels <- "Levels of 'x' are not present in 'new_order': "
 warn_new_order_nonchar <- paste0("checkinput::all_characters(new_order,",
                                  " allow_empty = TRUE, allow_NA = TRUE) is not TRUE")
@@ -75,8 +75,7 @@ expect_warning(
   expect_identical(
     reorder_levels(x = input_missing_levels, new_order = new_order),
     output_missing_levels),
-  pattern = paste0("Added values of 'x' that were not present in its levels to",
-                   " its levels: 'NA'"),
+  pattern = "Added missing levels for values of 'x':\n'NA'",
   strict = TRUE, fixed = TRUE)
 
 expect_warning(
@@ -124,7 +123,7 @@ expect_silent(
 # all values of 'new_order' missing from 'x'
 expect_warning(
   expect_identical(reorder_levels(x = input, new_order = letters[4:6]), input),
-  pattern = paste0(warn_append_levels, "'a',\n", paste_quoted(letters[2:3])),
+  pattern = paste0(warn_append_levels, "'a', ", paste_quoted(letters[2:3])),
   strict = TRUE, fixed = TRUE)
 
 expect_error(reorder_levels(x = 1:3, new_order = new_order),

--- a/man/wrap_text.Rd
+++ b/man/wrap_text.Rd
@@ -39,6 +39,13 @@ except for double spaces after periods, question marks and exclamation marks
 The call \code{wrap_text(x, width)} can be replaced by
 \code{paste0(strwrap(x, width + 1L), collapse = "\\n")} if \code{x} has length one and
 \code{ignore_newlines} is \code{TRUE}.
+
+
+Using \code{wrap_text()} on \code{x} of variable length, e.g., in the text of warnings
+that report a file path or a user-provided variable name, makes the location
+of newlines unpredictable and thus difficult to test reliably. To circumvent
+this, put the constant part in the front of the message and hardcode newlines
+using \verb{\\n}.
 }
 
 \section{Notes}{


### PR DESCRIPTION
- Make the location of newlines more predictable by hardcoding newlines using `\n` instead of using `wrap_text()` in warnings.
- Combine elements of workflows `check-standard.yaml` and `check-no-suggests.yaml` to check if the package functions correctly without the dependencies listed in 'Suggests' which I use for documentation.