### PR TITLE
Devel

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Imports:
 Remotes: github::JesseAlderliesten/checkinput
 Suggests:
     stats,
-    tinytest,
+    tinytest (>= 1.4.1),
     tools
 URL: https://github.com/JesseAlderliesten/progutils
 BugReports: https://github.com/JesseAlderliesten/progutils/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,21 +4,25 @@
 - Dependency `checkinput`: increase minimum version from `0.1.0` to `0.5.0`.
   This increases the minimum version of `R` to `4.1.0` but removes the
   dependency on `vctrs`.
+- Dependency `tinytest`: declare version `>= 1.4.1` because I use argument
+  `strict` in `expect_message()` and `expect_warning()`.
 - `create_dir()`: `dir` ending in `\.` now is, as was documented, an error
   instead of silently denoting the working directory. Hardcoding newlines instead of
   using `wrap_text()` makes it easier to test warnings.
 
 ### Miscellaneous
 - Run tests when checking the package. Adjusted tests and example to accommodate
-  bugfix to tools::file_path_sans_ext() in R 4.6.0.
-- `check_case()` and `replace_vals()`: outcomment failing tests that seem to
-  fail on sort order for uppercase vs. lowercase characters (differences caused
-  by locale settings (see `Sys.getlocale()`)?
+  bugfix to `tools::file_path_sans_ext()` in `R 4.6.0`.
+- `replace_vals()`: updated tests that failed because of different sort order for 
+  uppercase vs. lowercase characters caused by locale settings (see
+  `Sys.getlocale()`). Solved a similar problem for `check_input()` by hardcoding
+  factor instead of using `as.factor()` when they involve the same uppercase and
+  lowercase letters.
 - Make the location of newlines more predictable by hardcoding newlines using
  `\n` instead of using `wrap_text()` in warnings.
 - Combine elements of workflows `check-standard.yaml` and `check-no-suggests.yaml`
   to check if the package functions correctly without the dependencies listed in
-  'Suggests' which I use for documentation.
+  `Suggests` which I use for documentation.
 
 
 # progutils 0.0.5
@@ -30,7 +34,7 @@
 
 ### Miscellaneous
 - No need to import `osVersion` from `utils` because `utils` itself is imported.
-- GitHub action `check-standard` now also runs on R 4.1.0 on ubuntu and Windows,
+- GitHub action `check-standard` now also runs on `R 4.1.0` on ubuntu and Windows,
   is triggered every Saturday on 04:23 UTC, and can be triggered manually
   (trigger it once manually on the main branch to be able to trigger it manually
   on other branches).
@@ -54,7 +58,7 @@
 # progutils 0.0.3
 
 ### Breaking changes
-- Increased minimum version of `checkinput` to 0.1.0.
+- Increased minimum version of `checkinput` to `0.1.0`.
 - `create_dir()` now shows the warnings if creating a directory fails.
 - `create_dir()` now use `winslash = "/"` instead of `winslash = "\\"` to
   normalise paths.
@@ -73,8 +77,8 @@
 - Added `stats` and `tools` as dependencies in the `Suggests` field because they
   are linked to in help pages.
 - No longer import `methods::formalArgs()`.
-- Replaced section title `Note` (created through @Note) by section title 'Notes'
-  (created through @section Notes). Idem for 'Programming note'.
+- Replaced section title `Note` (created through `@Note`) by section title
+  `Notes` (created through `@section Notes`). Idem for `Programming note`.
 - `create_dir()`: move some documentation to `create_path()`; document format of
   date-time stamp with same case as `strftime()`.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,11 +13,10 @@
 ### Miscellaneous
 - Run tests when checking the package. Adjusted tests and example to accommodate
   bugfix to `tools::file_path_sans_ext()` in `R 4.6.0`.
-- `replace_vals()`: updated tests that failed because of different sort order for 
-  uppercase vs. lowercase characters caused by locale settings (see
-  `Sys.getlocale()`). Solved a similar problem for `check_input()` by hardcoding
-  factor instead of using `as.factor()` when they involve the same uppercase and
-  lowercase letters.
+- `check_input()` and `replace_vals()`: updated tests that failed because of
+  different sort order for uppercase vs. lowercase characters caused by locale
+  settings (see `Sys.getlocale()`). This also affects the order of factor levels
+  and thus the output of `as.factor()`.
 - Make the location of newlines more predictable by hardcoding newlines using
  `\n` instead of using `wrap_text()` in warnings.
 - Combine elements of workflows `check-standard.yaml` and `check-no-suggests.yaml`

--- a/R/check_case.R
+++ b/R/check_case.R
@@ -13,6 +13,11 @@
 #' [error][stop], [warning], or [message] if `signal` is `error`, `warning`, or
 #' `message`, respectively. Values are silently returned if `signal` is `quiet`.
 #'
+#' @section Notes:
+#' Sort order depends on the used [locale][locales] (see also the section
+#' `Details` of [Comparison]), which also affects if uppercase characters are
+#' sorted before or after lowercase characters.
+#'
 #' @family functions to check equality
 #'
 #' @examples

--- a/inst/tinytest/test_check_case.R
+++ b/inst/tinytest/test_check_case.R
@@ -10,9 +10,10 @@ x <- c(lower_upper_mixed, lower_upper, lower_mixed, upper_mixed,
        mixed_diff, fine)
 x_out <- c("ff", "Ff", "FF", "gg", "gG", "Gg", "GG", "h", "H", "j", "J",
            "kk", "Kk", "Ll", "LL", "mM", "Mm")
+x_out_alt <- c("FF", "Ff", "ff", "GG", "Gg", "gG", "gg", "H", "h", "J", "j",
+               "Kk", "kk", "LL", "Ll", "Mm", "mM")
 
 msg_text <- "'x' contains values that only differ in their case: "
-msg_text_x <- paste0(msg_text, paste_quoted(x_out))
 
 
 #### Tests ####
@@ -25,54 +26,96 @@ expect_silent(expect_identical(check_case(x = c("aB", "aba")), character(0)))
 expect_silent(expect_identical(check_case(x = fine), character(0)))
 
 ##### Values with a single problem #####
-expect_warning(
-  expect_identical(check_case(x = lower_upper_mixed, signal = "warning"),
-                   c("ff", "Ff", "FF", "gg", "gG", "Gg", "GG")),
-  pattern = paste0(msg_text, "'ff', 'Ff', 'FF', 'gg', 'gG', 'Gg', 'GG'"),
-  strict = TRUE, fixed = TRUE
+expect_true(
+  identical(suppressWarnings(check_case(x = lower_upper_mixed, signal = "warning")),
+            c("ff", "Ff", "FF", "gg", "gG", "Gg", "GG")) ||
+    identical(suppressWarnings(check_case(x = lower_upper_mixed, signal = "warning")),
+              c("FF", "Ff", "GG", "Gg", "ff", "gG", "gg"))
 )
 
 expect_warning(
-  expect_identical(check_case(x = lower_upper, signal = "warning"),
-                   c("h", "H", "j", "J")),
-  pattern = paste0(msg_text, "'h', 'H', 'j', 'J'"), strict = TRUE, fixed = TRUE
+  check_case(x = lower_upper_mixed, signal = "warning"),
+  pattern = msg_text, strict = TRUE, fixed = TRUE
+)
+
+expect_true(
+  identical(suppressWarnings(check_case(x = lower_upper, signal = "warning")),
+            c("h", "H", "j", "J")) ||
+    identical(suppressWarnings(check_case(x = lower_upper, signal = "warning")),
+              c("H", "h", "J", "j"))
 )
 
 expect_warning(
-  expect_identical(check_case(x = lower_mixed, signal = "warning"), c("kk", "Kk")),
-  pattern = paste0(msg_text, "'kk', 'Kk'"), strict = TRUE, fixed = TRUE
+  check_case(x = lower_upper, signal = "warning"),
+  pattern = msg_text, strict = TRUE, fixed = TRUE
+)
+
+expect_true(
+  identical(suppressWarnings(check_case(x = lower_mixed, signal = "warning")),
+            c("kk", "Kk")) ||
+    identical(suppressWarnings(check_case(x = lower_mixed, signal = "warning")),
+              c("Kk", "kk"))
 )
 
 expect_warning(
-  expect_identical(check_case(x = upper_mixed, signal = "warning"), c("Ll", "LL")),
-  pattern = paste0(msg_text, "'Ll', 'LL'"), strict = TRUE, fixed = TRUE
+  check_case(x = lower_mixed, signal = "warning"),
+  pattern = msg_text, strict = TRUE, fixed = TRUE
+)
+
+expect_true(
+  identical(suppressWarnings(check_case(x = upper_mixed, signal = "warning")), c("Ll", "LL")) ||
+    identical(suppressWarnings(check_case(x = upper_mixed, signal = "warning")), c("LL", "Ll"))
 )
 
 expect_warning(
-  expect_identical(check_case(x = mixed_diff, signal = "warning"), c("mM", "Mm")),
-  pattern = paste0(msg_text, "'mM', 'Mm'"), strict = TRUE, fixed = TRUE
+  check_case(x = upper_mixed, signal = "warning"),
+  pattern = msg_text, strict = TRUE, fixed = TRUE
+)
+
+expect_true(
+  identical(suppressWarnings(check_case(x = mixed_diff, signal = "warning")),
+            c("mM", "Mm")) ||
+    identical(suppressWarnings(check_case(x = mixed_diff, signal = "warning")),
+              c("Mm", "mM"))
+)
+
+expect_warning(
+  check_case(x = mixed_diff, signal = "warning"),
+  pattern = msg_text, strict = TRUE, fixed = TRUE
 )
 
 ##### Values with multiple problems #####
 expect_error(
-  check_case(x = x, signal = "error"), pattern = msg_text_x, fixed = TRUE
+  check_case(x = x, signal = "error"),
+  pattern = msg_text, fixed = TRUE
+)
+
+expect_true(
+  identical(suppressWarnings(check_case(x = x, signal = "warning")), x_out) ||
+    identical(suppressWarnings(check_case(x = x, signal = "warning")), x_out_alt)
 )
 
 expect_warning(
-  expect_identical(check_case(x = x, signal = "warning"), x_out),
-  pattern = msg_text_x, strict = TRUE, fixed = TRUE
+  check_case(x = x, signal = "warning"),
+  pattern = msg_text, strict = TRUE, fixed = TRUE
+)
+
+expect_true(
+  identical(check_case(x = x, signal = "message"), x_out) ||
+    identical(check_case(x = x, signal = "message"), x_out_alt)
 )
 
 expect_message(
-  expect_identical(check_case(x = x, signal = "message"), x_out),
-  pattern = msg_text_x, strict = TRUE, fixed = TRUE
+  check_case(x = x, signal = "message"),
+  pattern = msg_text, strict = TRUE, fixed = TRUE
 )
 
 expect_silent(
-  expect_identical(check_case(x = x, signal = "quiet"), x_out)
+  expect_identical(check_case(x = x, signal = "quiet"), x_out) ||
+    identical(check_case(x = x, signal = "quiet"), x_out_alt)
 )
 
 
 #### Remove objects used in tests ####
 rm(fine, lower_mixed, lower_upper, lower_upper_mixed, mixed_diff, msg_text,
-   msg_text_x, upper_mixed, x, x_out)
+   upper_mixed, x, x_out, x_out_alt)

--- a/inst/tinytest/test_check_case.R
+++ b/inst/tinytest/test_check_case.R
@@ -25,52 +25,52 @@ expect_silent(expect_identical(check_case(x = c("aB", "aba")), character(0)))
 expect_silent(expect_identical(check_case(x = fine), character(0)))
 
 ##### Values with a single problem #####
-# expect_warning(
-#   expect_identical(check_case(x = lower_upper_mixed, signal = "warning"),
-#                    c("ff", "Ff", "FF", "gg", "gG", "Gg", "GG")),
-#   pattern = paste0(msg_text, "'ff', 'Ff', 'FF', 'gg', 'gG', 'Gg', 'GG'"),
-#   strict = TRUE, fixed = TRUE
-# )
-#
-# expect_warning(
-#   expect_identical(check_case(x = lower_upper, signal = "warning"),
-#                    c("h", "H", "j", "J")),
-#   pattern = paste0(msg_text, "'h', 'H', 'j', 'J'"), strict = TRUE, fixed = TRUE
-# )
-#
-# expect_warning(
-#   expect_identical(check_case(x = lower_mixed, signal = "warning"), c("kk", "Kk")),
-#   pattern = paste0(msg_text, "'kk', 'Kk'"), strict = TRUE, fixed = TRUE
-# )
-#
-# expect_warning(
-#   expect_identical(check_case(x = upper_mixed, signal = "warning"), c("Ll", "LL")),
-#   pattern = paste0(msg_text, "'Ll', 'LL'"), strict = TRUE, fixed = TRUE
-# )
-#
-# expect_warning(
-#   expect_identical(check_case(x = mixed_diff, signal = "warning"), c("mM", "Mm")),
-#   pattern = paste0(msg_text, "'mM', 'Mm'"), strict = TRUE, fixed = TRUE
-# )
-#
-# ##### Values with multiple problems #####
-# expect_error(
-#   check_case(x = x, signal = "error"), pattern = msg_text_x, fixed = TRUE
-# )
-#
-# expect_warning(
-#   expect_identical(check_case(x = x, signal = "warning"), x_out),
-#   pattern = msg_text_x, strict = TRUE, fixed = TRUE
-# )
-#
-# expect_message(
-#   expect_identical(check_case(x = x, signal = "message"), x_out),
-#   pattern = msg_text_x, strict = TRUE, fixed = TRUE
-# )
-#
-# expect_silent(
-#   expect_identical(check_case(x = x, signal = "quiet"), x_out)
-# )
+expect_warning(
+  expect_identical(check_case(x = lower_upper_mixed, signal = "warning"),
+                   c("ff", "Ff", "FF", "gg", "gG", "Gg", "GG")),
+  pattern = paste0(msg_text, "'ff', 'Ff', 'FF', 'gg', 'gG', 'Gg', 'GG'"),
+  strict = TRUE, fixed = TRUE
+)
+
+expect_warning(
+  expect_identical(check_case(x = lower_upper, signal = "warning"),
+                   c("h", "H", "j", "J")),
+  pattern = paste0(msg_text, "'h', 'H', 'j', 'J'"), strict = TRUE, fixed = TRUE
+)
+
+expect_warning(
+  expect_identical(check_case(x = lower_mixed, signal = "warning"), c("kk", "Kk")),
+  pattern = paste0(msg_text, "'kk', 'Kk'"), strict = TRUE, fixed = TRUE
+)
+
+expect_warning(
+  expect_identical(check_case(x = upper_mixed, signal = "warning"), c("Ll", "LL")),
+  pattern = paste0(msg_text, "'Ll', 'LL'"), strict = TRUE, fixed = TRUE
+)
+
+expect_warning(
+  expect_identical(check_case(x = mixed_diff, signal = "warning"), c("mM", "Mm")),
+  pattern = paste0(msg_text, "'mM', 'Mm'"), strict = TRUE, fixed = TRUE
+)
+
+##### Values with multiple problems #####
+expect_error(
+  check_case(x = x, signal = "error"), pattern = msg_text_x, fixed = TRUE
+)
+
+expect_warning(
+  expect_identical(check_case(x = x, signal = "warning"), x_out),
+  pattern = msg_text_x, strict = TRUE, fixed = TRUE
+)
+
+expect_message(
+  expect_identical(check_case(x = x, signal = "message"), x_out),
+  pattern = msg_text_x, strict = TRUE, fixed = TRUE
+)
+
+expect_silent(
+  expect_identical(check_case(x = x, signal = "quiet"), x_out)
+)
 
 
 #### Remove objects used in tests ####

--- a/inst/tinytest/test_check_case.R
+++ b/inst/tinytest/test_check_case.R
@@ -10,8 +10,8 @@ x <- c(lower_upper_mixed, lower_upper, lower_mixed, upper_mixed,
        mixed_diff, fine)
 x_out <- c("ff", "Ff", "FF", "gg", "gG", "Gg", "GG", "h", "H", "j", "J",
            "kk", "Kk", "Ll", "LL", "mM", "Mm")
-x_out_alt <- c("FF", "Ff", "ff", "GG", "Gg", "gG", "gg", "H", "h", "J", "j",
-               "Kk", "kk", "LL", "Ll", "Mm", "mM")
+x_out_alt <- c("FF", "Ff", "GG", "Gg", "H", "J", "Kk", "LL", "Ll", "Mm",
+               "ff", "gG", "gg", "h", "j", "kk", "mM")
 
 msg_text <- "'x' contains values that only differ in their case: "
 
@@ -42,7 +42,7 @@ expect_true(
   identical(suppressWarnings(check_case(x = lower_upper, signal = "warning")),
             c("h", "H", "j", "J")) ||
     identical(suppressWarnings(check_case(x = lower_upper, signal = "warning")),
-              c("H", "h", "J", "j"))
+              c("H", "J", "h", "j"))
 )
 
 expect_warning(
@@ -101,8 +101,8 @@ expect_warning(
 )
 
 expect_true(
-  identical(check_case(x = x, signal = "message"), x_out) ||
-    identical(check_case(x = x, signal = "message"), x_out_alt)
+  identical(suppressMessages(check_case(x = x, signal = "message")), x_out) ||
+    identical(suppressMessages(check_case(x = x, signal = "message")), x_out_alt)
 )
 
 expect_message(

--- a/inst/tinytest/test_check_case.R
+++ b/inst/tinytest/test_check_case.R
@@ -111,8 +111,10 @@ expect_message(
 )
 
 expect_silent(
-  expect_identical(check_case(x = x, signal = "quiet"), x_out) ||
-    identical(check_case(x = x, signal = "quiet"), x_out_alt)
+  expect_true(
+    identical(check_case(x = x, signal = "quiet"), x_out) ||
+      identical(check_case(x = x, signal = "quiet"), x_out_alt)
+  )
 )
 
 

--- a/inst/tinytest/test_replace_vals.R
+++ b/inst/tinytest/test_replace_vals.R
@@ -12,6 +12,8 @@ x_upper <- toupper(x)
 x_upper_out <- x_upper
 x_upper_out[2] <- new
 x_mixed <- c(x, x_upper)
+x_mixed_factor <- factor(x = c("k", "l", "m", "K", "L", "M"),
+                         levels = c("k", "K", "l", "L", "m", "M"))
 x_mixed_out <- c(x_out, x_upper_out)
 x_NA_factor <- addNA(as.factor(x_NA))
 
@@ -101,13 +103,13 @@ for(allow_multiple in c(TRUE, FALSE)) {
       x_mixed_out),
     pattern = msg_replace_mult, strict = TRUE, fixed = TRUE)
 
-  # expect_message(
-  #   expect_identical(
-  #     replace_vals(x = as.factor(x_mixed), old = old, new = new,
-  #                  ignore_case = TRUE, allow_multiple = allow_multiple,
-  #                  signal_case_old = "quiet"),
-  #     factor(x_mixed_out, levels = c("k", "K", "b", "m", "M"))),
-  #   pattern = msg_replace_mult, strict = TRUE, fixed = TRUE)
+  expect_message(
+    expect_identical(
+      replace_vals(x = x_mixed_factor, old = old, new = new,
+                   ignore_case = TRUE, allow_multiple = allow_multiple,
+                   signal_case_old = "quiet"),
+      factor(x_mixed_out, levels = c("k", "K", "b", "m", "M"))),
+    pattern = msg_replace_mult, strict = TRUE, fixed = TRUE)
 }
 
 # Multiple case-insensitive matches to a single 'old' that are not
@@ -456,15 +458,16 @@ expect_warning(
     fixed = TRUE),
   pattern = paste0(warn_match_case, "'old' ('p', 'v', 'y'): 'V'"), fixed = TRUE)
 
-# expect_warning(
-#   expect_error(
-#     replace_vals(x = as.factor(c("p", "V", "z")), old = c("p", "v", "y"), new = new,
-#                  ignore_case = TRUE, allow_multiple = FALSE,
-#                  signal_case_old = "warning"),
-#     pattern = paste0(warn_mult_old, "'p', 'v', 'y') matched 'x'",
-#                      " ('p', 'V', 'z'): 'p', 'V'"),
-#     fixed = TRUE),
-#   pattern = paste0(warn_match_case, "'old' ('p', 'v', 'y'): 'V'"), fixed = TRUE)
+expect_warning(
+  expect_error(
+    replace_vals(x = factor(x = c("p", "V", "z"), levels = c("p", "V", "z")),
+                 old = c("p", "v", "y"), new = new,
+                 ignore_case = TRUE, allow_multiple = FALSE,
+                 signal_case_old = "warning"),
+    pattern = paste0(warn_mult_old, "'p', 'v', 'y') matched 'x'",
+                     " ('p', 'V', 'z'): 'p', 'V'"),
+    fixed = TRUE),
+  pattern = paste0(warn_match_case, "'old' ('p', 'v', 'y'): 'V'"), fixed = TRUE)
 
 expect_warning(
   expect_identical(
@@ -511,13 +514,13 @@ expect_message(
     x_mixed_out),
   pattern = msg_replace_mult, strict = TRUE, fixed = TRUE)
 
-# expect_message(
-#   expect_identical(
-#     replace_vals(x = as.factor(x_mixed), old = c("l", "L"), new = new,
-#                  ignore_case = TRUE, allow_multiple = FALSE,
-#                  signal_case_old = "error"),
-#     factor(x = x_mixed_out, levels = c("k", "K", "b", "m", "M"))),
-#   pattern = msg_replace_mult, strict = TRUE, fixed = TRUE)
+expect_message(
+  expect_identical(
+    replace_vals(x = x_mixed_factor, old = c("l", "L"), new = new,
+                 ignore_case = TRUE, allow_multiple = FALSE,
+                 signal_case_old = "error"),
+    factor(x = x_mixed_out, levels = c("k", "K", "b", "m", "M"))),
+  pattern = msg_replace_mult, strict = TRUE, fixed = TRUE)
 
 # If 'ignore_case' is 'FALSE', values in 'old' that differ in their case lead to
 # to an error if they both match to 'x' and 'allow_multiple' is FALSE
@@ -529,13 +532,13 @@ expect_error(
                    x_quoted, ", 'K', 'L', 'M'): 'l', 'L'"),
   fixed = TRUE)
 
-# expect_error(
-#   replace_vals(x = as.factor(x_mixed), old = c("l", "L"), new = new,
-#                ignore_case = FALSE, allow_multiple = FALSE,
-#                signal_case_old = "warning"),
-#   pattern = paste0(warn_mult_old, "'l', 'L') matched 'x'",
-#                    " ('k', 'K', 'l', 'L', 'm', 'M'): 'l', 'L'"),
-#   fixed = TRUE)
+expect_error(
+  replace_vals(x = x_mixed_factor, old = c("l", "L"), new = new,
+               ignore_case = FALSE, allow_multiple = FALSE,
+               signal_case_old = "warning"),
+  pattern = paste0(warn_mult_old, "'l', 'L') matched 'x'",
+                   " ('k', 'K', 'l', 'L', 'm', 'M'): 'l', 'L'"),
+  fixed = TRUE)
 
 # If 'ignore_case' is 'FALSE', values in 'old' that differ in their case are
 # fine if they both match to 'x' and 'allow_multiple' is TRUE
@@ -547,13 +550,13 @@ expect_message(
     x_mixed_out),
   pattern = msg_replace_mult, strict = TRUE, fixed = TRUE)
 
-# expect_message(
-#   expect_identical(
-#     replace_vals(x = as.factor(x_mixed), old = c("l", "L"), new = new,
-#                  ignore_case = FALSE, allow_multiple = TRUE,
-#                  signal_case_old = "warning"),
-#     factor(x = x_mixed_out, levels = c("k", "K", "b", "m", "M"))),
-#   pattern = msg_replace_mult, strict = TRUE, fixed = TRUE)
+expect_message(
+  expect_identical(
+    replace_vals(x = x_mixed_factor, old = c("l", "L"), new = new,
+                 ignore_case = FALSE, allow_multiple = TRUE,
+                 signal_case_old = "warning"),
+    factor(x = x_mixed_out, levels = c("k", "K", "b", "m", "M"))),
+  pattern = msg_replace_mult, strict = TRUE, fixed = TRUE)
 
 ##### NA and "" #####
 expect_message(

--- a/man/check_case.Rd
+++ b/man/check_case.Rd
@@ -28,6 +28,13 @@ Values in \code{x} that only differ from each other in their case generate an
 \code{message}, respectively. Values are silently returned if \code{signal} is \code{quiet}.
 }
 
+\section{Notes}{
+
+Sort order depends on the used \link[=locales]{locale} (see also the section
+\code{Details} of \link{Comparison}), which also affects if uppercase characters are
+sorted before or after lowercase characters.
+}
+
 \examples{
 x <- c("Ee", "Ee", "LL", "Ll")
 try(check_case(x = x, signal = "error"))


### PR DESCRIPTION
### Breaking changes
- Dependency `tinytest`: declare version `>= 1.4.1` because I use argument `strict` in `expect_message()` and `expect_warning()`.

### Miscellaneous
- `check_input()` and `replace_vals()`: updated tests that failed because of different sort order for uppercase vs. lowercase characters caused by locale settings (see `Sys.getlocale()`). This also affects the order of factor levels and thus the output of `as.factor()`.