### PR TITLE
Version 0.0.7

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: progutils
 Title: Programming Utilities
-Version: 0.0.6
+Version: 0.0.7
 Authors@R: 
     person("Jesse", "Alderliesten", email = "jessealderliesten@hotmail.com",
     role = c("aut", "cre"), comment = c(ORCID = "0000-0003-1132-4310"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+# progutils 0.0.7
+
+### Breaking changes
+- `paste_quoted()`: return `""` as `'\"\"'` instead of `''`. Indicate the class
+  of non-logical `NA`s. Do not allow list-type `x`. These changes also affect
+  warnings and messages in other functions.
+- `replace_vals()`: `new` is also processed through `paste_quoted()` in the
+  message indicating the replacement.
+- `vect_to_char()`: return `""` as `\"\"` instead of ` `. Indicate the class of
+  non-logical `NA`s. This change also affects warnings and messages in other
+  functions.
+
+
 # progutils 0.0.6
 
 ### Breaking changes

--- a/R/are_equal.R
+++ b/R/are_equal.R
@@ -23,7 +23,8 @@
 #' [\R FAQ 7.31](
 #' https://CRAN.R-project.org/doc/manuals/R-FAQ.html#Why-doesn_0027t-R-think-these-numbers-are-equal_003f)
 #' for background on numerical equality;
-#' the vignette about type coercion: `vignette("Type_Coercion", package = "checkinput")`.
+#' the vignette about type coercion in package `checkinput`:
+#' `vignette("Type_Coercion", package = "checkinput")`.
 #'
 #' @family functions to check equality
 #'

--- a/R/paste_quoted.R
+++ b/R/paste_quoted.R
@@ -1,15 +1,18 @@
 #' Concatenate x to a string with quoted elements.
 #'
-#' Concatenate a vector to a string with quoted elements, returning `NULL` as
-#' `"'NULL'"` and other zero-length objects as `"'<class>(0)'"`, e.g.,
-#' `"'logical(0)'"`.
+#' Concatenate a vector or factor to a string with quoted elements.
 #'
-#' @param x Vector to be converted to a character string.
+#' @details
+#' `paste_quoted()` returns `NULL` as `"'NULL'"`, other zero-length objects as
+#' `"'<class>(0)'"` (e.g., `"'logical(0)'"`), `""` as `'""'`, and non-logical
+#' `NA`s as `"'NA_<class>_'"` (e.g., `"'NA_real_'"`; for [factors][factor] this
+#' is `"'NA_character_'"`).
+#'
+#' @param x Vector or factor to be converted to a character string.
 #'
 #' @returns
 #' A character string consisting of the elements of `x` surrounded by single
-#' quotes, separated by commas. `NULL` is returned as `"'NULL'"`, other
-#' zero-length objects are returned as `"'<class>(0)'"`, e.g., `"'logical(0)'"`.
+#' quotes, separated by commas. See `details` on handling of some special values.
 #'
 #' @section Notes:
 #' An error occurs if multiple arguments are provided because then `x` probably
@@ -30,7 +33,7 @@
 #'
 #' @export
 paste_quoted <- function(x) {
-  stopifnot(is.vector(x) || is.factor(x) || is.null(x))
+  stopifnot(is.vector(x) || is.factor(x) || is.null(x), !is.list(x))
 
   if(!is.null(names(x))) {
     warning_text <- "'x' has names, these will be discarded."
@@ -41,12 +44,28 @@ paste_quoted <- function(x) {
     warning(wrap_text(warning_text))
   }
 
-  if(is.null(x)) {
-    x <- "NULL"
+  if(is.factor(x)) {
+    x <- as.character(x)
   }
 
   if(length(x) == 0L) {
-    x <- paste0(class(x), "(0)")
+    if(is.null(x)) {
+      x <- "NULL"
+    } else {
+      x <- paste0(class(x), "(0)")
+    }
+  }
+
+  bool_NA <- is.na(x) & !is.nan(x)
+  if(any(bool_NA)) {
+    if(!is.logical(x)) {
+      x[bool_NA] <- paste0("NA_", class(x), "_")
+    }
+  }
+
+  bool_zchar <- !nzchar(x)
+  if(any(bool_zchar)) {
+    x[bool_zchar] <- "\"\""
   }
 
   # Same as paste0(sQuote(x, q = FALSE), collapse = ", ") but much faster

--- a/R/replace_vals.R
+++ b/R/replace_vals.R
@@ -175,7 +175,7 @@ replace_vals <- function(
            ") matched 'x' (", paste_quoted(x), "): ", old_detected_quoted)
     }
     if(!quiet) {
-      message("Replaced values ", old_detected_quoted, " with '", new, "'")
+      message("Replaced values ", old_detected_quoted, " with ", paste_quoted(new))
     }
     x[ind_replace] <- new
   } else {

--- a/R/vect_to_char.R
+++ b/R/vect_to_char.R
@@ -1,10 +1,16 @@
 #' Convert a vector to a character string
 #'
 #' Convert a vector to a character string, preserving names, rounding numeric
-#' values, returning `NULL` as `"'NULL'"` and other zero-length objects as
-#' `"'<class>(0)'"`, e.g., `"'logical(0)'"`.
+#' values.
 #'
-#' @param x A vector, [factor], non-dataframe [list], or `NULL`.
+#' @details
+#' `vect_to_char()` returns `NULL` as `"NULL"`, other zero-length objects as
+#' `"<class>(0)"` (e.g., `"logical(0)"`), `""` as `'""'`, and non-logical `NA`s
+#' as `"NA_<class>_"` (e.g., `"NA_real_"`; for [factors][factor] this is
+#' `"NA_character_"`).
+#'
+#' @param x A vector, [factor], `NULL`, or a non-dataframe [list] (unlisted
+#' through `unlist(x, use.names = TRUE)`, with a warning).
 #' @param signif Positive number of length one, rounded to the nearest positive
 #' integer indicating the number of significant digits to round numeric `x` to.
 #' @param sep Character string of length one used to separate the names and the
@@ -23,8 +29,7 @@
 #' the name-value pairs are separated by `collapse`, thus returning a character
 #' *string*.
 #'
-#' `NULL` is returned as `"'NULL'"`, other zero-length objects are returned as
-#' `"'<class>(0)'"`, e.g., `"'logical(0)'"`.
+#' See `details` on handling of some special values.
 #'
 #' @section Programming notes:
 #' To get a cross-tabulation of `x` into a character string, one can use
@@ -76,12 +81,37 @@ vect_to_char <- function(x, signif = 3L, width = Inf, sep = ": ",
     x <- signif(x = x, digits = signif)
   }
 
-  if(is.null(x)) {
-    x <- "NULL"
+  if(is.factor(x)) {
+    x <- as.character(x)
   }
 
   if(length(x) == 0L) {
-    x <- paste0(class(x), "(0)")
+    if(is.null(x)) {
+      x <- "NULL"
+    } else {
+      x <- paste0(class(x), "(0)")
+    }
+  }
+
+  bool_NA <- is.na(x) & !is.nan(x)
+  if(any(bool_NA)) {
+    if(!is.list(x)) {
+      if(!is.logical(x)) {
+        x[bool_NA] <- paste0("NA_", class(x), "_")
+      }
+    } else {
+      NA_new <- paste0("NA_",
+                       vapply(X = x[bool_NA], FUN = class,
+                              FUN.VALUE = character(1), USE.NAMES = FALSE),
+                       "_")
+      NA_new[NA_new == "NA_logical_"] <- "NA"
+      x[bool_NA] <- NA_new
+    }
+  }
+
+  bool_zchar <- !nzchar(x)
+  if(any(bool_zchar)) {
+    x[bool_zchar] <- "\"\""
   }
 
   if(!is.null(names(x))) {

--- a/inst/tinytest/test_paste_quoted.R
+++ b/inst/tinytest/test_paste_quoted.R
@@ -5,14 +5,11 @@
 
 
 #### Create objects to use in tests ####
-list_input <-  list("a", c("a", "b"), c("a", "b", "a"),
-                    c(3, 4), NULL, NA, NA_character_)
-list_output <- list("'a'", "'a', 'b'", "'a', 'b', 'a'",
-                    "'3', '4'", "'NULL'", "'NA'", "'NA'")
-list_input_zerolength <- list(NULL, character(0), numeric(0), logical(0),
-                              vector(mode = "list"), "")
+list_input <-  list("a", c("a", "b"), c("a", "b", "a"), c(3, 4))
+list_output <- list("'a'", "'a', 'b'", "'a', 'b', 'a'", "'3', '4'")
+list_input_zerolength <- list(NULL, character(0), numeric(0), logical(0), "")
 list_output_zerolength <- list("'NULL'", "'character(0)'", "'numeric(0)'",
-                               "'logical(0)'", "'list(0)'", "''")
+                               "'logical(0)'", "'\"\"'")
 x_fact_ind <- c(4:6, 5L)
 x_fact <- as.factor(letters[x_fact_ind])
 x_fact_int <- as.factor(x_fact_ind)
@@ -38,7 +35,19 @@ expect_identical(toString(c("a", "b")), paste(c("a", "b"), collapse = ", "))
 #### Tests ####
 for(index in seq_along(list_input)) {
   expect_identical(paste_quoted(x = list_input[[index]]), list_output[[index]])
+  expect_identical(paste_quoted(x = factor(list_input[[index]], exclude = NULL)),
+                   list_output[[index]])
 }
+expect_identical(paste_quoted(x = NA), "'NA'")
+expect_identical(paste_quoted(x = NA_character_), "'NA_character_'")
+expect_identical(paste_quoted(x = factor(NA, exclude = NULL)), "'NA_character_'")
+expect_identical(paste_quoted(x = factor(NA_character_, exclude = NULL)),
+                 "'NA_character_'")
+
+expect_identical(paste_quoted(x = NULL), "'NULL'")
+expect_identical(paste_quoted(x = as.factor(NULL)), "'character(0)'")
+expect_silent(expect_identical(paste_quoted(c("a", "", "c", NA_character_)),
+                               "'a', '\"\"', 'c', 'NA_character_'"))
 
 expect_silent(expect_identical(paste_quoted(x = x_fact), "'d', 'e', 'f', 'e'"))
 expect_silent(expect_identical(paste_quoted(x = x_fact_int), "'4', '5', '6', '5'"))
@@ -71,6 +80,12 @@ for(x in list(data.frame(a = 314), as.matrix(data.frame(a = 314)))) {
   expect_error(
     paste_quoted(x),
     pattern = "is.vector(x) || is.factor(x) || is.null(x) is not TRUE", fixed = TRUE)
+}
+
+for(x in list(list(a = 314), vector(mode = "list"))) {
+  expect_error(
+    paste_quoted(x),
+    pattern = "!is.list(x) is not TRUE", fixed = TRUE)
 }
 
 

--- a/inst/tinytest/test_reorder_cols.R
+++ b/inst/tinytest/test_reorder_cols.R
@@ -98,7 +98,7 @@ expect_warning(
   expect_identical(reorder_cols(x = test_df, new_order = new_order_weird),
                    output_df),
   pattern = paste0("Dropped values of 'new_order' that are not present in",
-                   " column names of 'x':\n'', 'NA', 'd'"),
+                   " column names of 'x':\n'\"\"', 'NA_character_', 'd'"),
   strict = TRUE, fixed = TRUE)
 
 # Weird input to 'new_order', matrix input to 'x'.
@@ -113,7 +113,7 @@ expect_warning(
   expect_identical(reorder_cols(x = test_mat, new_order = new_order_weird),
                    output_mat),
   pattern = paste0("Dropped values of 'new_order' that are not present in",
-                   " column names of 'x':\n'', 'NA', 'd'"),
+                   " column names of 'x':\n'\"\"', 'NA_character_', 'd'"),
   strict = TRUE, fixed = TRUE)
 
 # Factor input to 'new_order'

--- a/inst/tinytest/test_reorder_levels.R
+++ b/inst/tinytest/test_reorder_levels.R
@@ -67,7 +67,7 @@ expect_warning(
   expect_identical(
     reorder_levels(x = vals_NA, new_order = new_order),
     factor(x = vals_NA, levels = c(new_order, NA), exclude = NULL)),
-  pattern = paste0(warn_append_levels, "'NA'"),
+  pattern = paste0(warn_append_levels, "'NA_character_'"),
   strict = TRUE, fixed = TRUE)
 
 # Factor with NA missing from its levels. Testing the warnings separately.
@@ -75,14 +75,15 @@ expect_warning(
   expect_identical(
     reorder_levels(x = input_missing_levels, new_order = new_order),
     output_missing_levels),
-  pattern = "Added missing levels for values of 'x':\n'NA'",
+  pattern = "Added missing levels for values of 'x':\n'NA_character_'",
   strict = TRUE, fixed = TRUE)
 
 expect_warning(
   expect_identical(
     reorder_levels(x = input_missing_levels, new_order = new_order),
     output_missing_levels),
-  pattern = paste0(warn_append_levels, "'NA'"), strict = TRUE, fixed = TRUE)
+  pattern = paste0(warn_append_levels, "'NA_character_'"),
+  strict = TRUE, fixed = TRUE)
 
 # factor with unused levels
 expect_warning(
@@ -96,14 +97,16 @@ expect_warning(
   expect_identical(
     reorder_levels(x = input_NA_levels, new_order = new_order),
     factor(x = input_unused_levels, levels = new_order)),
-  pattern = paste0(warn_drop_levels, "'NA'"), strict = TRUE, fixed = TRUE)
+  pattern = paste0(warn_drop_levels, "'NA_character_'"),
+  strict = TRUE, fixed = TRUE)
 
 # factor with NA in its values and its levels, NA missing from 'new_order'
 expect_warning(
   expect_identical(
     reorder_levels(x = input_NA_levels_val, new_order = new_order),
     factor(input_NA_levels_val, levels = c(new_order[1:2], NA), exclude = NULL)),
-  pattern = paste0(warn_append_levels, "'NA'"), strict = TRUE, fixed = TRUE)
+  pattern = paste0(warn_append_levels, "'NA_character_'"),
+  strict = TRUE, fixed = TRUE)
 
 # some values of 'new_order' missing from 'x'
 expect_warning(

--- a/inst/tinytest/test_replace_vals.R
+++ b/inst/tinytest/test_replace_vals.R
@@ -575,56 +575,59 @@ expect_message(
   expect_identical(
     replace_vals(x = x_NA, old = NA_character_, new = new),
     c("", "b", x)),
-  pattern = "Replaced values 'NA' with 'b'", strict = TRUE, fixed = TRUE)
+  pattern = "Replaced values 'NA_character_' with 'b'", strict = TRUE, fixed = TRUE)
 
 expect_message(
   expect_identical(
     replace_vals(x = x_NA_factor, old = NA_character_, new = new),
     factor(c("", "b", x), levels = c("", x, "b"))),
-  pattern = "Replaced values 'NA' with 'b'", strict = TRUE, fixed = TRUE)
+  pattern = "Replaced values 'NA_character_' with 'b'", strict = TRUE, fixed = TRUE)
 
 expect_message(
   expect_identical(
     replace_vals(x = x_NA, old = "", new = new),
     c("b", NA_character_, x)),
-  pattern = "Replaced values '' with 'b'", strict = TRUE, fixed = TRUE)
+  pattern = "Replaced values '\"\"' with 'b'", strict = TRUE, fixed = TRUE)
 
 expect_message(
   expect_identical(
     replace_vals(x = x_NA_factor, old = "", new = new),
     addNA(factor(c("b", NA_character_, x), levels = c("b", x)))),
-  pattern = "Replaced values '' with 'b'", strict = TRUE, fixed = TRUE)
+  pattern = "Replaced values '\"\"' with 'b'", strict = TRUE, fixed = TRUE)
 
 expect_message(
   expect_identical(
     replace_vals(x = x_NA, old = "", new = NA_character_),
     c(NA_character_, NA_character_, x)),
-  pattern = "Replaced values '' with 'NA'", strict = TRUE, fixed = TRUE)
+  pattern = "Replaced values '\"\"' with 'NA_character_'",
+  strict = TRUE, fixed = TRUE)
 
 expect_message(
   expect_identical(
     replace_vals(x = x_NA_factor, old = "", new = NA_character_),
     factor(x = c(NA_character_, NA_character_, x), levels = c(NA_character_, x),
            exclude = NULL)),
-  pattern = "Replaced values '' with 'NA'", strict = TRUE, fixed = TRUE)
+  pattern = "Replaced values '\"\"' with 'NA_character_'",
+  strict = TRUE, fixed = TRUE)
 
 expect_message(
   expect_identical(
     replace_vals(x = x, old = old, new = ""),
     c("k", "", "m")),
-  pattern = "Replaced values 'l' with ''", strict = TRUE, fixed = TRUE)
+  pattern = "Replaced values 'l' with '\"\"'", strict = TRUE, fixed = TRUE)
 
 expect_message(
   expect_identical(
     replace_vals(x = x_NA_factor, old = old, new = ""),
     addNA(as.factor(c("", NA, "k", "", "m")))),
-  pattern = "Replaced values 'l' with ''", strict = TRUE, fixed = TRUE)
+  pattern = "Replaced values 'l' with '\"\"'", strict = TRUE, fixed = TRUE)
 
 expect_message(
   expect_identical(
     replace_vals(x = c("", x), old = "", new = NA_character_),
     c(NA_character_, x)),
-  pattern = "Replaced values '' with 'NA'", strict = TRUE, fixed = TRUE)
+  pattern = "Replaced values '\"\"' with 'NA_character_'",
+  strict = TRUE, fixed = TRUE)
 
 ##### Erroneous input #####
 expect_error(

--- a/inst/tinytest/test_vect_to_char.R
+++ b/inst/tinytest/test_vect_to_char.R
@@ -40,6 +40,16 @@ expect_identical(
 
 
 #### Tests ####
+expect_silent(expect_identical(vect_to_char(NULL), "NULL"))
+expect_silent(expect_identical(vect_to_char(numeric(0)), "numeric(0)"))
+expect_silent(expect_identical(vect_to_char(c("a", "", "c", NA_character_)),
+                               "a, \"\", c, NA_character_"))
+
+expect_silent(expect_identical(vect_to_char(as.factor(NULL)), "character(0)"))
+expect_silent(expect_identical(vect_to_char(as.factor(numeric(0))), "character(0)"))
+expect_silent(expect_identical(vect_to_char(as.factor(c("a", "", "c", NA_character_))),
+                               "a, \"\", c, NA_character_"))
+
 expect_silent(expect_identical(vect_to_char(x = x_in), x_out_named))
 expect_silent(expect_identical(vect_to_char(x = unname(x_in)),
                                paste(x_in, collapse = ", ")))
@@ -84,8 +94,13 @@ expect_silent(expect_identical(
        x = gsub(pattern = ": ", replacement = "=", x = x_out_char, fixed = TRUE),
        fixed = TRUE)))
 
-expect_silent(expect_identical(vect_to_char(x = x_in_InfNa),
-                 paste(names(x_in_InfNa), x_in_InfNa, sep = ": ", collapse = ", ")))
+expect_silent(
+  expect_identical(
+    vect_to_char(x = x_in_InfNa),
+    paste0("am: -1, bm: -2, i: 9, l: NA_numeric_, m: NaN,",
+           " n: Inf, o: -Inf, j: 10, z: 26, a: 1, b: 2, c: 3")
+  )
+)
 
 # If the use of 'signif_custom()' is implemented, the next test should change to:
 # expect_identical(vect_to_char(x = c(10^c(-1, 5)/7)), "0.0143, 14286")
@@ -98,7 +113,7 @@ expect_silent(expect_identical(vect_to_char(x = x_fact_num),
 
 expect_warning(expect_identical(
   vect_to_char(x = list(x_in_InfNa, b, unname(b)), signif = 2),
-  paste0("am: -1, bm: -2, i: 9, l: NA, m: NaN, n: Inf, o: -Inf, j: 10, z: 26,",
+  paste0("am: -1, bm: -2, i: 9, l: NA_numeric_, m: NaN, n: Inf, o: -Inf, j: 10, z: 26,",
          " a: 1, b: 2, c: 3, a: 0.14, b: 0.29, c: 0.43, : 0.14, : 0.29, : 0.43")),
   pattern = "Unlisted 'x' to obtain a vector!", strict = TRUE)
 

--- a/man/are_equal.Rd
+++ b/man/are_equal.Rd
@@ -45,7 +45,8 @@ are_equal(x = 3, y = c(2, 3, 3 + 1e-8, NA, Inf))
 
 \href{https://CRAN.R-project.org/doc/manuals/R-FAQ.html#Why-doesn_0027t-R-think-these-numbers-are-equal_003f}{\R FAQ 7.31}
 for background on numerical equality;
-the vignette about type coercion: \code{vignette("Type_Coercion", package = "checkinput")}.
+the vignette about type coercion in package \code{checkinput}:
+\code{vignette("Type_Coercion", package = "checkinput")}.
 
 Other functions to check equality: 
 \code{\link{check_case}()},

--- a/man/paste_quoted.Rd
+++ b/man/paste_quoted.Rd
@@ -7,17 +7,20 @@
 paste_quoted(x)
 }
 \arguments{
-\item{x}{Vector to be converted to a character string.}
+\item{x}{Vector or factor to be converted to a character string.}
 }
 \value{
 A character string consisting of the elements of \code{x} surrounded by single
-quotes, separated by commas. \code{NULL} is returned as \code{"'NULL'"}, other
-zero-length objects are returned as \code{"'<class>(0)'"}, e.g., \code{"'logical(0)'"}.
+quotes, separated by commas. See \code{details} on handling of some special values.
 }
 \description{
-Concatenate a vector to a string with quoted elements, returning \code{NULL} as
-\code{"'NULL'"} and other zero-length objects as \code{"'<class>(0)'"}, e.g.,
-\code{"'logical(0)'"}.
+Concatenate a vector or factor to a string with quoted elements.
+}
+\details{
+\code{paste_quoted()} returns \code{NULL} as \code{"'NULL'"}, other zero-length objects as
+\code{"'<class>(0)'"} (e.g., \code{"'logical(0)'"}), \code{""} as \code{'""'}, and non-logical
+\code{NA}s as \code{"'NA_<class>_'"} (e.g., \code{"'NA_real_'"}; for \link[=factor]{factors} this
+is \code{"'NA_character_'"}).
 }
 \section{Notes}{
 

--- a/man/vect_to_char.Rd
+++ b/man/vect_to_char.Rd
@@ -14,7 +14,8 @@ vect_to_char(
 )
 }
 \arguments{
-\item{x}{A vector, \link{factor}, non-dataframe \link{list}, or \code{NULL}.}
+\item{x}{A vector, \link{factor}, \code{NULL}, or a non-dataframe \link{list} (unlisted
+through \code{unlist(x, use.names = TRUE)}, with a warning).}
 
 \item{signif}{Positive number of length one, rounded to the nearest positive
 integer indicating the number of significant digits to round numeric \code{x} to.}
@@ -41,13 +42,17 @@ is returned, wrapping on a per-element basis. If \code{collapse} is not \code{NU
 the name-value pairs are separated by \code{collapse}, thus returning a character
 \emph{string}.
 
-\code{NULL} is returned as \code{"'NULL'"}, other zero-length objects are returned as
-\code{"'<class>(0)'"}, e.g., \code{"'logical(0)'"}.
+See \code{details} on handling of some special values.
 }
 \description{
 Convert a vector to a character string, preserving names, rounding numeric
-values, returning \code{NULL} as \code{"'NULL'"} and other zero-length objects as
-\code{"'<class>(0)'"}, e.g., \code{"'logical(0)'"}.
+values.
+}
+\details{
+\code{vect_to_char()} returns \code{NULL} as \code{"NULL"}, other zero-length objects as
+\code{"<class>(0)"} (e.g., \code{"logical(0)"}), \code{""} as \code{'""'}, and non-logical \code{NA}s
+as \code{"NA_<class>_"} (e.g., \code{"NA_real_"}; for \link[=factor]{factors} this is
+\code{"NA_character_"}).
 }
 \section{Programming notes}{
 


### PR DESCRIPTION
### Breaking changes
- `paste_quoted()`: return `""` as `'\"\"'` instead of `''`. Indicate the class
  of non-logical `NA`s. Do not allow list-type `x`. These changes also affect
  warnings and messages in other functions.
- `replace_vals()`: `new` is also processed through `paste_quoted()` in the
  message indicating the replacement.
- `vect_to_char()`: return `""` as `\"\"` instead of ` `. Indicate the class of
  non-logical `NA`s. This change also affects warnings and messages in other
  functions.