### PR TITLE
progutils 0.0.10.9002

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: progutils
 Title: Programming Utilities
-Version: 0.0.10.9001
+Version: 0.0.10.9002
 Authors@R: 
     person("Jesse", "Alderliesten", email = "jessealderliesten@hotmail.com",
     role = c("aut", "cre"), comment = c(ORCID = "0000-0003-1132-4310"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: progutils
 Title: Programming Utilities
-Version: 0.0.10.9002
+Version: 0.0.11
 Authors@R: 
     person("Jesse", "Alderliesten", email = "jessealderliesten@hotmail.com",
     role = c("aut", "cre"), comment = c(ORCID = "0000-0003-1132-4310"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,21 +1,8 @@
-# progutils 0.0.10.9002
-
-### Work in progress
-Removed or out-commented various tests to be able to have a pass-all-checks
-baseline after introducing the breaking changes detailed below.
-
-Work on test files that need to be updated:
-
-- `test_create_dir.R`: re-inserted updated versions of out-commented tests.
-- `test_create_path.R`: uses `expect_true(endsWith(...))` instead of
-  `expect_identical(...)`. Still has some out-commented `expect_silent()` to get
-  rid of spurious errors on MacOS because there the part before the output of
-  `tempdir()` contains repeated slashes leading to a spurious warning from
-  `is_path()`.
-- `test_is_path.R`: testing is incomplete.
+# progutils 0.0.11
 
 ### Breaking changes
 - `create_dir()` now uses `is_filename()` to check if `filename` is valid.
+- `create_path` now uses `is_path()` to check that `dir` is a valid path.
 - `create_tempdir()` now only writes in subdirectories of `tempdir()` and uses
   `is_path()` to check that `subdir` is valid.
 - `file_path_sans_ext()`: rename to `file_path_no_ext()` to distinguish it from

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,30 +1,17 @@
-# progutils 0.0.10.9001
+# progutils 0.0.10.9002
 
 ### Work in progress
-Work on test files that need to be updated (see `NEWS` for `progutils 0.0.10.9000`):
-
-- `test_create_path.R`: uses `expect_true(endsWith(...))` instead of `regexec()`
-  proposed in version `0.0.10.9000`. Has some out-commented `expect_silent()` to
-  get rid of spurious errors on MacOS because there the part before the output
-  of `tempdir()` contains repeated slashes leading to a spurious warning from
-  `is_path()`.
-
-
-# progutils 0.0.10.9000
-
-### Work in progress
-
 Removed or out-commented various tests to be able to have a pass-all-checks
 baseline after introducing the breaking changes detailed below.
 
-Test files that need to be updated:
+Work on test files that need to be updated:
 
-- `test_create_dir.R`: removed and out-commented various `expect_silent()`
-  statements to get rid of spurious errors on MacOS because there the part
-  before the output of `tempdir()` contains repeated slashes leading to a
-  spurious warning from `is_path()`.
-- `test_create_path.R`: out-commented most tests that use `expect_identical()`.
-  These need to use `regexec()` like the first test to work.
+- `test_create_dir.R`: re-inserted updated versions of out-commented tests.
+- `test_create_path.R`: uses `expect_true(endsWith(...))` instead of
+  `expect_identical(...)`. Still has some out-commented `expect_silent()` to get
+  rid of spurious errors on MacOS because there the part before the output of
+  `tempdir()` contains repeated slashes leading to a spurious warning from
+  `is_path()`.
 - `test_is_path.R`: testing is incomplete.
 
 ### Breaking changes

--- a/R/create_dir.R
+++ b/R/create_dir.R
@@ -2,9 +2,10 @@
 #'
 #' Create a directory if it does not yet exist.
 #'
-#' @param dir Non-empty character string containing the path to a directory that
-#' should be created if it does not yet exist. A dot (i.e., ".") indicates the
-#' current working directory.
+#' @param dir Non-empty [character string][checkinput::is_character()]
+#' containing a [valid path][is_path()] to a directory that should be created if
+#' it does not yet exist. A dot (i.e., `"."`) indicates the current working
+#' directory.
 #' @param add_date `TRUE` or `FALSE`: create a subdirectory with the current
 #' date in the [format][strftime()] `YYYY_mm_dd`?
 #'

--- a/R/create_path.R
+++ b/R/create_path.R
@@ -119,6 +119,8 @@ create_path <- function(filename, format_stamp = "%Y_%m_%d_%H_%M_%S",
     }
   }
 
+  is_path(dir)
+
   file_path <- file.path(create_dir(dir = dir, add_date = add_date),
                          filename_gsub)
   file_path <- normalizePath(path = file_path, winslash = "/", mustWork = FALSE)

--- a/R/is_path.R
+++ b/R/is_path.R
@@ -33,18 +33,6 @@
 #' @returns
 #' `TRUE`: an error occurs if `path` is not a valid path.
 #'
-#' @section Programming notes:
-#'
-#' To do:
-#' - Also disallow path components to **start** with a dot?
-#'
-#' See also
-#' - https://github.com/r-lib/usethis/blob/main/R/directory.R
-#' - https://github.com/r-lib/usethis/blob/main/tests/testthat/test-directory.R
-#' - https://docs.racket-lang.org/reference/windowspaths.html
-#' - function `progutils::create_path()`
-#' - packages `fs`.
-#'
 #' @seealso
 #' [create_path()] to create a path (with references there about file paths),
 #' [create_dir()] to create a directory if it does not yet exist,

--- a/inst/tinytest/test_create_dir.R
+++ b/inst/tinytest/test_create_dir.R
@@ -74,7 +74,10 @@ expect_true(endsWith(
 
 # without date directory, directory already exists
 dir_no_date_v2 <- create_dir(dir = dir, add_date = FALSE)
-expect_identical(dir_no_date, dir_no_date_v2)
+expect_true(endsWith(
+  dir_no_date_v2,
+  suffix = file.path(tempdir_basename, "testcreatedir", "temp_subdirF_dateF")
+))
 
 # with date directory
 dir <- file.path(my_tempdir, "temp_subdirF_dateT")

--- a/inst/tinytest/test_create_dir.R
+++ b/inst/tinytest/test_create_dir.R
@@ -1,14 +1,3 @@
-#### Notes ####
-# - A temporary directory is used to write the added directories to. The files
-#   written to that directory by this script are deleted when they are not
-#   needed anymore. Deleting the entire temporary directory would lead to
-#   problems because other R-processes write to the same temporary directory.
-# - The returned message is only checked for containing 'Created directory' or
-#   'already exists' because getting the correct type and number of slashes in
-#   the string to compare with the path recorded in the message is brittle.
-#   Checking the path is thus left to expect_identical() and
-#   expect_true(dir.exists(expected_path)).
-
 tinytest::report_side_effects()
 
 

--- a/inst/tinytest/test_create_dir.R
+++ b/inst/tinytest/test_create_dir.R
@@ -15,17 +15,26 @@ tinytest::report_side_effects()
 #### Test the examples ####
 my_tempdir <- normalizePath(path = file.path(tempdir(), "testcreatedir"),
                             winslash = "/", mustWork = FALSE)
+tempdir_basename <- basename(tempdir())
+
 res_dir_one <- create_dir(dir = file.path(my_tempdir, "dir_one"),
                           add_date = FALSE)
 expect_true(dir.exists(res_dir_one))
 
 res_dir_one_v2 <- create_dir(dir = file.path(my_tempdir, "dir_one"),
                              add_date = FALSE)
-# expect_identical(res_dir_one, res_dir_one_v2)
+expect_true(endsWith(
+  res_dir_one,
+  suffix = file.path(tempdir_basename, "testcreatedir", "dir_one")
+))
+expect_true(endsWith(
+  res_dir_one_v2,
+  suffix = file.path(tempdir_basename, "testcreatedir", "dir_one")
+))
 
-# On case-insensitive file systems such as Windows and macOS, the created
-# directory is the same as 'res_dir_one'. On case-sensitive file systems such as
-# Ubuntu, it differs in case from 'res_dir_one'.
+# On case-insensitive file systems such as Windows and macOS, the directory
+# created below is the same as 'res_dir_one'. On case-sensitive file systems
+# such as Ubuntu, it differs in case from 'res_dir_one'.
 # To do:
 # - Issues a spurious warning on MacOS because there the part before the output
 #   of 'tempdir()' contains repeated slashes. Can re-wrap in 'expect_silent()'
@@ -39,90 +48,59 @@ expect_true(dir.exists(res_dir_two))
 
 # Cleaning up
 unlink(dirname(res_dir_one), recursive = TRUE)
-rm(my_tempdir, res_dir_one, res_dir_one_v2, res_dir_two)
+rm(my_tempdir, res_dir_one, res_dir_one_v2, res_dir_two, tempdir_basename)
 
 
 #### Tests ####
 my_tempdir <- normalizePath(path = file.path(tempdir(), "testcreatedir"),
                             winslash = "/", mustWork = FALSE)
 dir.create(my_tempdir)
+tempdir_basename <- basename(tempdir())
 my_tempfile <- file.path(my_tempdir, "test_df.csv")
 # Write csv-file, modified from example in help(write.table)
 write.table(x = data.frame(a = "a", b = pi), file = my_tempfile)
-
 
 # without date directory
 dir <- file.path(my_tempdir, "temp_subdirF_dateF")
 expected_path <- dir
 
-expect_silent(expect_false(dir.exists(expected_path)))
-# expect_silent(
-#   expect_identical(
-    create_dir(dir = dir, add_date = FALSE) # ,
-    # normalizePath(expected_path, winslash = "/", mustWork = FALSE)))
+expect_false(dir.exists(expected_path))
+dir_no_date <- create_dir(dir = dir, add_date = FALSE)
 expect_true(dir.exists(expected_path))
+expect_true(endsWith(
+  dir_no_date,
+  suffix = file.path(tempdir_basename, "testcreatedir", "temp_subdirF_dateF")
+))
 
 # without date directory, directory already exists
-expect_identical(
-  create_dir(dir = dir, add_date = FALSE),
-  normalizePath(expected_path, winslash = "/", mustWork = FALSE))
-if(expect_true(dir.exists(expected_path))) {
-  expect_equal(unlink(x = expected_path, recursive = TRUE), 0,
-               info = "Check if removing temporary directories was successful")
-}
+dir_no_date_v2 <- create_dir(dir = dir, add_date = FALSE)
+expect_identical(dir_no_date, dir_no_date_v2)
 
 # with date directory
 dir <- file.path(my_tempdir, "temp_subdirF_dateT")
 expected_path <- file.path(dir, format(Sys.time(), format = "%Y_%m_%d"))
 
-# expect_false(dir.exists(expected_path))
-# expect_silent(
-#   expect_identical(
-     create_dir(dir = dir, add_date = TRUE)
-#     ,
-#     normalizePath(expected_path, winslash = "/", mustWork = FALSE))
-#     )
-# expect_true(dir.exists(expected_path))
-
-# with date directory, directory already exists
-# expect_silent(
-  expect_identical(
-    create_dir(dir = dir, add_date = TRUE),
-    normalizePath(expected_path, winslash = "/", mustWork = FALSE))# )
-
-# Also recognise that a directory already exists if it has subdirectories
-# expect_silent(
-  expect_identical(
-    create_dir(dir = dir),
-    normalizePath(expected_path, winslash = "/", mustWork = FALSE))# )
-if(expect_true(dir.exists(expected_path))) {
-  expect_equal(
-    unlink(x = dirname(expected_path), recursive = TRUE), 0,
-    info = "Check if removing temporary directories was successful")
-}
+expect_false(dir.exists(expected_path))
+dir_date <- create_dir(dir = dir, add_date = TRUE)
+expect_true(dir.exists(expected_path))
+expect_true(endsWith(
+  dir_date,
+  suffix = file.path(tempdir_basename, "testcreatedir", "temp_subdirF_dateT",
+                     format(Sys.time(), format = "%Y_%m_%d"))
+))
 
 # with subdirectories, with date directory
 dir <- file.path(my_tempdir, "temp_subdirT_dateT")
 expected_path <- file.path(dir, "subdir", format(Sys.time(), format = "%Y_%m_%d"))
 
-# expect_false(dir.exists(expected_path))
-# expect_silent(
-#   expect_identical(
-     create_dir(dir = file.path(dir, "subdir"), add_date = TRUE)
-#     ,
-#     normalizePath(expected_path, winslash = "/", mustWork = FALSE)))
-# expect_true(dir.exists(expected_path))
-
-# with subdirectories, with date directory, directory already exists
-# expect_silent(
-  expect_identical(
-    create_dir(dir = file.path(dir, "subdir"), add_date = TRUE),
-    normalizePath(expected_path, winslash = "/", mustWork = FALSE))# )
-if(expect_true(dir.exists(expected_path))) {
-  expect_equal(
-    unlink(x = dirname(dirname(expected_path)), recursive = TRUE),
-    0, info = "Check if removing temporary directories was successful")
-}
+expect_false(dir.exists(expected_path))
+dir_subdir_date <- create_dir(dir = file.path(dir, "subdir"), add_date = TRUE)
+expect_true(dir.exists(expected_path))
+expect_true(endsWith(
+  dir_subdir_date,
+  suffix = file.path(tempdir_basename, "testcreatedir", "temp_subdirT_dateT", "subdir",
+                     format(Sys.time(), format = "%Y_%m_%d"))
+))
 
 # Checks on input to 'dir'
 for(dir in list(3, "", character(0), NULL, c("temp_p1", "temp_p2"))) {
@@ -151,11 +129,15 @@ for(dir in list(paste0(file.path(my_tempdir, "temp"), "//"),
     pattern = "Repeated '/' or '\\'", fixed = TRUE)
 }
 
-# NB. 'dir' equal to '.' can be used to denote the current working directory.
+# NB. 'dir' equal to '.' or '..' can be used to denote the current working
+# directory and its parent directory, respectively. By default, this will add
+# the folder with the current date to those directories. This is not tested
+# here to prevent writing in the working directory.
 for(dir in list(file.path(my_tempdir, " "),
                 file.path(my_tempdir, "temp "),
                 file.path(my_tempdir, "temp ", "subtemp"),
                 file.path(my_tempdir, "."),
+                file.path(my_tempdir, ".."),
                 file.path(my_tempdir, "temp."),
                 file.path(my_tempdir, "temp.", "subtemp"))) {
   expect_error(
@@ -182,4 +164,5 @@ unlink(my_tempdir, recursive = TRUE)
 
 
 #### Remove objects used in tests ####
-rm(add_date, dir, expected_path, my_tempdir, my_tempfile)
+rm(add_date, dir, dir_no_date, dir_no_date_v2, dir_date, dir_subdir_date,
+   expected_path, my_tempdir, my_tempfile, tempdir_basename)

--- a/inst/tinytest/test_create_tempdir.R
+++ b/inst/tinytest/test_create_tempdir.R
@@ -1,14 +1,3 @@
-#### Notes ####
-# - A temporary directory is used to write the added directories to. The files
-#   written to that directory by this script are deleted when they are not
-#   needed anymore. Deleting the entire temporary directory would lead to
-#   problems because other R-processes write to the same temporary directory.
-# - The returned message is only checked for containing 'Created directory' or
-#   'already exists' because getting the correct type and number of slashes in
-#   the string to compare with the path recorded in the message is brittle.
-#   Checking the path is thus left to expect_identical() and
-#   expect_true(dir.exists(expected_path)).
-
 tinytest::report_side_effects()
 
 

--- a/man/create_dir.Rd
+++ b/man/create_dir.Rd
@@ -7,9 +7,10 @@
 create_dir(dir = file.path(".", "output"), add_date = TRUE)
 }
 \arguments{
-\item{dir}{Non-empty character string containing the path to a directory that
-should be created if it does not yet exist. A dot (i.e., ".") indicates the
-current working directory.}
+\item{dir}{Non-empty \link[checkinput:is_character]{character string}
+containing a \link[=is_path]{valid path} to a directory that should be created if
+it does not yet exist. A dot (i.e., \code{"."}) indicates the current working
+directory.}
 
 \item{add_date}{\code{TRUE} or \code{FALSE}: create a subdirectory with the current
 date in the \link[=strftime]{format} \code{YYYY_mm_dd}?}

--- a/man/create_path.Rd
+++ b/man/create_path.Rd
@@ -21,9 +21,10 @@ the stamp to be added in front of the file name. No stamp is added if
 treated as part of the filename, such that the same restrictions apply, see
 \code{Details}.}
 
-\item{dir}{Non-empty character string containing the path to a directory that
-should be created if it does not yet exist. A dot (i.e., ".") indicates the
-current working directory.}
+\item{dir}{Non-empty \link[checkinput:is_character]{character string}
+containing a \link[=is_path]{valid path} to a directory that should be created if
+it does not yet exist. A dot (i.e., \code{"."}) indicates the current working
+directory.}
 
 \item{add_date}{\code{TRUE} or \code{FALSE}: create a subdirectory with the current
 date in the \link[=strftime]{format} \code{YYYY_mm_dd}?}

--- a/man/is_path.Rd
+++ b/man/is_path.Rd
@@ -43,24 +43,6 @@ removed in Windows; and words that are reserved names in Windows.
 In contrast to functions from \code{checkinput}, \code{is_path} will produce an error
 if \code{path} is not a valid path.
 }
-\section{Programming notes}{
-
-
-To do:
-\itemize{
-\item Also disallow path components to \strong{start} with a dot?
-}
-
-See also
-\itemize{
-\item https://github.com/r-lib/usethis/blob/main/R/directory.R
-\item https://github.com/r-lib/usethis/blob/main/tests/testthat/test-directory.R
-\item https://docs.racket-lang.org/reference/windowspaths.html
-\item function \code{progutils::create_path()}
-\item packages \code{fs}.
-}
-}
-
 \section{References}{
 
 \itemize{


### PR DESCRIPTION
### Work in progress
Removed or out-commented various tests to be able to have a pass-all-checks baseline after introducing the breaking changes detailed below.

Work on test files that need to be updated:

- `test_create_dir.R`: re-inserted updated versions of out-commented tests.
- `test_create_path.R`: uses `expect_true(endsWith(...))` instead of `expect_identical(...)`. Still has some out-commented `expect_silent()` to get rid of spurious errors on MacOS because there the part before the output of `tempdir()` contains repeated slashes leading to a spurious warning from `is_path()`.
- `test_is_path.R`: testing is incomplete.

### Breaking changes
- `create_dir()` now uses `is_filename()` to check if `filename` is valid.
- `create_tempdir()` now only writes in subdirectories of `tempdir()` and uses `is_path()` to check that `subdir` is valid.
- `file_path_sans_ext()`: rename to `file_path_no_ext()` to distinguish it from `tools::file_path_sans_ext()` when linking to documentation; add argument `compression`.
- `wrap_text()` collapses leading and trailing whitespace and, if `ignore_newlines` is `TRUE`, leading and trailing newlines into a single blank character instead of removing them; and retains leading and trailing newlines if `ignore_newlines` is `FALSE`.
- Add functions `file_path_ext()`, `is_filename()` and `is_path()`.

### Miscellaneous
- `NEWS`: stylistic update.
- `README`: refer to website when appropriate. Stylistic update.