### PR TITLE
progutils 0.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: progutils
 Title: Programming Utilities
-Version: 0.0.14
+Version: 0.1.0
 Authors@R: 
     person("Jesse", "Alderliesten", email = "jessealderliesten@hotmail.com",
     role = c("aut", "cre"), comment = c(ORCID = "0000-0003-1132-4310"))
@@ -9,7 +9,7 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 Imports: 
-    checkinput (>= 0.6.0),
+    checkinput (>= 0.7.0),
     utils
 Remotes: github::JesseAlderliesten/checkinput
 Suggests:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,11 @@
-# progutils 0.0.14
+# progutils 0.0.15
 
 ### Miscellaneous
-- Remove references to non-exported functions.
-- Stylistic updates to `See also` section and `Examples`.
+- ...
+
+
+# progutils 0.0.14
+- Stylistic updates.
 
 
 # progutils 0.0.13
@@ -12,11 +15,6 @@
   to the implicit prior default `FALSE`), fixing issue #1.
 
 
-### Miscellaneous
-- Update families and function titles to have a better package index.
-- Use a custom package index for the website.
-
-
 # progutils 0.0.12
 
 ### Breaking changes
@@ -24,16 +22,13 @@
   characters other than dots and underscores by underscores instead of replacing
   non-alphanumeric characters other than underscores by dots.
 
-### Miscellaneous
+### Documentation
 - `as.numeric_safe()`: moved `Note` to `Details`. Condensed example section.
 - `create_tempdir()`: add section `Usage in practice` which explains why using
   `create_tempdir()` is preferable over using `tempdir()`.
 - `head_tail()`: no longer erroneously document that `n` can be zero. Removed
   uninformative example.
-- `is_filename()`: updated warning if `filename` contains slashes, so it is
-  possible to call `is_filename()` from `create_file_path()`.
 - `is_path()`: add section `Programming notes` about file separators.
-- Stylistic updates to function documentation.
 
 
 # progutils 0.0.11
@@ -50,17 +45,9 @@
   `ignore_newlines` is `TRUE`, leading and trailing newlines into a single blank
   character instead of removing them. Retains leading and trailing newlines if
   `ignore_newlines` is `FALSE`.
+
+### Added functions
 - Add functions `file_path_ext()`, `is_filename()` and `is_path()`.
-
-### Miscellaneous
-- `NEWS`: stylistic update.
-- `README`: refer to website when appropriate. Stylistic update.
-
-
-# progutils 0.0.10
-
-### Miscellaneous
-- Add pkgdown website: `https://jessealderliesten.github.io/progutils/`.
 
 
 # progutils 0.0.9
@@ -70,6 +57,8 @@
   needed to use re-exported `paste_quoted()`.
 - `progutils::paste_quoted()`: move to `checkinput` and re-export it to
   `progutils`.
+
+### Added functions
 - Add function `create_tempdir()` to create a temporary directory that can
   safely be removed.
 
@@ -78,10 +67,12 @@
 
 ### Breaking changes
 - Removed unused `check_os_is_windows()`.
-- Added `head_tail()` to show the `head` and `tail` of an object.
 - Use `roxygen2` version 8.0.0.
 - `not_in()`: `x` and `table` have to be a vector or factor (as was always
   documented) to prevent returning `x` if `x` or `table` is a `list`.
+
+### Added functions
+- Add `head_tail()` to show the first and last part of an object.
 
 
 # progutils 0.0.7
@@ -109,20 +100,6 @@
   instead of silently denoting the working directory. Hardcode newlines instead
   of using `wrap_text()` makes it easier to test warnings.
 
-### Miscellaneous
-- Run tests when checking the package. Adjusted tests and example to accommodate
-  bugfix to `tools::file_path_sans_ext()` in `R 4.6.0`.
-- `check_input()` and `replace_vals()`: update tests that failed because of
-  different sort order for uppercase vs. lowercase characters caused by locale
-  settings (see `Sys.getlocale()`). This also affects the order of factor levels
-  and thus the output of `as.factor()`.
-- Make the location of newlines more predictable by hardcoding newlines using
- `\n` instead of using `wrap_text()` in warnings.
-- Combine elements of workflows `check-standard.yaml` and `check-no-suggests.yaml`
-  to check if the package functions correctly without the dependencies listed in
-  `Suggests` which I use for documentation.
-- Note that `not_in()` does not consider names when matching.
-
 
 # progutils 0.0.5
 
@@ -130,13 +107,6 @@
 - `replace_vals()`: gained argument `signal_old_ignore_case`. Bugfix for, and
   more consistent handling of, `NA` in factors. Values in messages are no longer
   sorted alphabetically.
-
-### Miscellaneous
-- No need to import `osVersion` from `utils` because `utils` itself is imported.
-- GitHub action `check-standard` now also runs on `R 4.1.0` on ubuntu and Windows,
-  is triggered every Saturday on 04:23 UTC, and can be triggered manually
-  (trigger it once manually on the main branch to be able to trigger it manually
-  on other branches).
 
 
 # progutils 0.0.4
@@ -150,14 +120,14 @@
 - `signal_text`: signal text to a user through an error, warning, or message.
 - `unpaste_unquote`: the opposite of `paste_quoted()`.
 
-### Miscellaneous
-- `progutils` now uses GitHub action `check-standard` on all branches.
-
 
 # progutils 0.0.3
 
 ### Breaking changes
 - `checkinput`: increased minimum version to `0.1.0`.
+- Add `stats` and `tools` as dependencies in the `Suggests` field because they
+  are linked to in help pages.
+- No longer import `methods::formalArgs()`.
 - `create_dir()`: show the warnings if creating a directory fails.
 - `create_dir()`: use `winslash = "/"` instead of `winslash = "\\"` to normalise
   paths.
@@ -172,18 +142,9 @@
 - `reorder_cols()`: reorder columns.
 - `reorder_levels()`: reorder factor levels.
 
-### Updated documentation
-- Add `stats` and `tools` as dependencies in the `Suggests` field because they
-  are linked to in help pages.
-- No longer import `methods::formalArgs()`.
-- Replace section title `Note` (created through `@Note`) by section title
-  `Notes` (created through `@section Notes`). Idem for `Programming note`.
+### Documentation
 - `create_dir()`: move some documentation to `create_path()`; document format of
   date-time stamp with same case as `strftime()`.
-
-### Miscellaneous ###
-- `progutils` now uses GitHub action `check-standard` on all branches (see
-  `?usethis::use_github_action()`).
 
 
 # progutils 0.0.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
-# progutils 0.0.15
+# progutils 0.1.0
 
-### Miscellaneous
-- ...
+### Breaking changes
+- Dependency `checkinput`: increase minimum version from `0.6.0` to `0.7.0` to
+  have the new default `all = FALSE` instead of `all = TRUE` in `make_natural()`.
 
 
 # progutils 0.0.14

--- a/README.Rmd
+++ b/README.Rmd
@@ -20,23 +20,12 @@ knitr::opts_chunk$set(
 `progutils` contains utility functions, for example to reorder values, check
 equality, construct messages, or handle files and directories.
 
-## Folder structure
-```
-├── .github
-│   └── workflows: workflows to run tests with GitHub Actions
-├── R: functions
-├── inst
-│   └── tinytest: tests
-├── man: help-files
-└── tests: setup to use 'tinytest' for testing
-```
-
 ## Installation
 You can visit the
 [progutils website](https://jessealderliesten.github.io/progutils/) to explore
 the package. To use `progutils`, you have to install it from
 [GitHub](https://github.com/JesseAlderliesten/progutils) using the following
-code in R (you need to run R as administrator):
+R code (you need to run R as administrator):
 
 ```{r, eval = FALSE}
 if(!requireNamespace("remotes", quietly = TRUE)) {

--- a/README.md
+++ b/README.md
@@ -10,23 +10,13 @@
 `progutils` contains utility functions, for example to reorder values,
 check equality, construct messages, or handle files and directories.
 
-## Folder structure
-
-    ├── .github
-    │   └── workflows: workflows to run tests with GitHub Actions
-    ├── R: functions
-    ├── inst
-    │   └── tinytest: tests
-    ├── man: help-files
-    └── tests: setup to use 'tinytest' for testing
-
 ## Installation
 
 You can visit the [progutils
 website](https://jessealderliesten.github.io/progutils/) to explore the
 package. To use `progutils`, you have to install it from
 [GitHub](https://github.com/JesseAlderliesten/progutils) using the
-following code in R (you need to run R as administrator):
+following R code (you need to run R as administrator):
 
 ``` r
 if(!requireNamespace("remotes", quietly = TRUE)) {

--- a/inst/tinytest/test_reorder_cols.R
+++ b/inst/tinytest/test_reorder_cols.R
@@ -38,12 +38,12 @@ expect_warning(
 
 
 #### Tests ####
-# Normal data.frame input
+# Normal data frame input
 expect_silent(
   expect_identical(reorder_cols(x = test_df, new_order = new_order), output_df)
 )
 
-# Weird data.frame input
+# Weird data frame input
 expect_warning(
   expect_error(
     reorder_cols(x = test_df_weird, new_order = new_order),
@@ -52,7 +52,7 @@ expect_warning(
   pattern = "Names are syntactically invalid: 'NA_character_', '\"\"'",
   strict = TRUE, fixed = TRUE)
 
-# data.frame input without column names
+# data frame input without column names
 expect_error(reorder_cols(x = unname(test_df), new_order = new_order),
              pattern = "'x' should have column names", fixed = TRUE)
 
@@ -78,7 +78,7 @@ expect_error(reorder_cols(x = unname(test_mat), new_order = new_order),
 expect_error(reorder_cols(x = test_df[, 1L, drop = TRUE], new_order = new_order),
              pattern = "'x' should have columns", fixed = TRUE)
 
-# data.frame with zero columns
+# data frame with zero columns
 expect_error(reorder_cols(x = test_df[, 0L, drop = TRUE], new_order = new_order),
              pattern = "'x' should have at least one column", fixed = TRUE)
 
@@ -90,7 +90,7 @@ expect_error(reorder_cols(x = test_mat[, 0L, drop = TRUE], new_order = new_order
 expect_error(reorder_cols(x = character(0), new_order = new_order),
              pattern = "'x' should have columns", fixed = TRUE)
 
-# Weird input to 'new_order', data.frame input to 'x'.
+# Weird input to 'new_order', data frame input to 'x'.
 expect_warning(
   expect_identical(reorder_cols(x = test_df, new_order = new_order_weird),
                    output_df),


### PR DESCRIPTION
### Breaking changes
- Dependency `checkinput`: increase minimum version from `0.6.0` to `0.7.0` to have the new default `all = FALSE` instead of `all = TRUE` in `make_natural()`.