### PR TITLE
Stylistic updates.

### DIFF
--- a/R/check_case.R
+++ b/R/check_case.R
@@ -3,15 +3,15 @@
 #' @inheritParams signal_text
 #' @param x Character vector to check.
 #'
+#' @details
+#' Values in `x` that only differ from each other in their case generate an
+#' [error][stop], [warning], or [message] if `signal` is `error`, `warning`, or
+#' `message`, respectively. Values are silently returned if `signal` is `quiet`.
+#'
 #' @returns
 #' Character vector with [unique][unique()], [sorted][sort()] values in `x` that
 #' only differ from each other in their case, or `character(0)` if no such
 #' values are present. The return is [invisible].
-#'
-#' @section Side effects:
-#' Values in `x` that only differ from each other in their case generate an
-#' [error][stop], [warning], or [message] if `signal` is `error`, `warning`, or
-#' `message`, respectively. Values are silently returned if `signal` is `quiet`.
 #'
 #' @section Notes:
 #' The sorting order in the result depends on the used [locale][locales] (see

--- a/R/create_dir.R
+++ b/R/create_dir.R
@@ -2,11 +2,10 @@
 #'
 #' Create a directory if it does not yet exist.
 #'
-#' @param dir Non-empty [character string][checkinput::is_character()]
+#' @param dir [Character string][checkinput::is_character()]
 #' containing a [valid path][is_path()] to a directory that should be created if
-#' it does not yet exist. [fs::path()] ensures the correct
-#' ([platform][.Platform]-dependent) file separator is used to indicate
-#' subdirectories and the dot (`"."`) indicates the [working directory][getwd()],
+#' it does not yet exist. [fs::path()] adds file separators and the dot (`"."`)
+#' indicates the [working directory][getwd()],
 #' such that by default a subdirectory with the current date in the
 #' [format][strftime()] `YYYY_mm_dd` in directory `output` below the working
 #' directory is created.
@@ -15,9 +14,6 @@
 #' current date in the [format][strftime()] `YYYY_mm_dd`?
 #'
 #' @details
-#' If creating the directory fails, the working directory is returned instead.
-#' This happens if `dir` points to an existing file instead of an directory.
-#'
 #' The absolute [normalised][normalizePath()] path is returned such that the
 #' returned path still works if the [working directory][getwd()] changes. On
 #' case-insensitive file systems (e.g., Windows and macOS), normalization
@@ -30,7 +26,8 @@
 #' A character string with the absolute [normalized][normalizePath()] path to
 #' the requested directory, returned [invisibly][invisible]. The
 #' [working directory][getwd()] is returned if an attempt to create a directory
-#' fails, with a warning.
+#' fails, with a warning. This happens if `dir` points to an existing file
+#' instead of an directory.
 #'
 #' @section Side effects:
 #' The directory indicated by the returned path is [created][create_dir()] if it
@@ -79,7 +76,7 @@
 #' rm(my_tempdir, res_dir_one, res_dir_one_v2, res_dir_two, res_dir_one_v3)
 #'
 #' @export
-create_dir <- function(dir = fs::path_wd("output"), add_date = TRUE) {
+create_dir <- function(dir = fs::path(".", "output"), add_date = TRUE) {
   stopifnot(is_path(dir), checkinput::is_logical(add_date))
 
   if(add_date) {

--- a/R/create_tempdir.R
+++ b/R/create_tempdir.R
@@ -8,9 +8,9 @@
 #'
 #' @details
 #' `subdir` is created inside [tempdir()] and an error is thrown if it already
-#' exists. This ensures that [removing][unlink()] the created directory does not
-#' remove files that are still needed by other processes (see `Usage in practice`
-#' below).
+#' exists or creating the directory fails. This ensures that [removing][unlink()]
+#' the created directory does not remove files that are still needed by other
+#' processes (see `Usage in practice` below).
 #'
 #' It is possible to create subdirectories inside a not-yet existing directory
 #' (e.g., to create `<tempdir>/output/outputsub` if `<tempdir>/output` does not
@@ -21,9 +21,8 @@
 #' returned [invisibly][invisible].
 #'
 #' @section Side effects:
-#' The requested temporary directory is [created][dir.create)()] if does not yet
-#' exist. An error is thrown if the directory already exists or creating the
-#' directory fails.
+#' The temporary directory indicated by the returned path is
+#' [created][dir.create()] if does not yet exist.
 #'
 #' @section Usage in practice:
 #' Examples and tests should **not** write to the [working directory][getwd()]

--- a/R/is_path.R
+++ b/R/is_path.R
@@ -21,7 +21,8 @@
 #' - `path` should not point to `tempdir()`: a temporary subdirectory should be
 #'   used instead (see [create_tempdir()]).
 #'
-#' Furthermore, if `path` contains a file extension, the part after the last
+#' Furthermore, if `path` contains a file extension or compression extension,
+#' the part after the last
 #' slash is considered the filename, which should adhere to the same
 #' restrictions as the path, and in addition should **not** contain `:` nor
 #' start with a space.
@@ -32,7 +33,7 @@
 #' path because they are silently removed in Windows; and words that are
 #' reserved names in Windows.
 #'
-#' `path` **not** necessarily has to contain a file separator (i.e., `/` or
+#' `path` does **not** have to contain a file separator (i.e., `/` or
 #' `\\`), such that `is_path()` can be used to check that input to [fs::path()]
 #' only contains allowed characters. Repeated file separators (e.g., `//` or
 #' `\\\\`) are treated as single separators, with a warning.
@@ -77,7 +78,7 @@
 #' paths), [create_dir()] to create a directory if it does not yet exist,
 #' [get_file_path()] to check if a file exists and is a unique match to a pattern
 #'
-#' `fs::path_sanitize()` to *remove* invalid characters from potential paths.
+#' `fs::path_sanitize()` to **remove** invalid characters from potential paths.
 #'
 #' @family functions to handle paths and directories
 #'

--- a/R/signal_text.R
+++ b/R/signal_text.R
@@ -16,12 +16,11 @@
 #' [message()] etc. that use [paste0()], see the `Examples`. Call [vect_to_char()]
 #' beforehand on `text` to control rounding and wrapping, see the last example.
 #'
-#' @returns
-#' `text`, returned [invisibly][invisible()].
-#'
-#' @section Side effects:
 #' `text` is signalled through an [error][stop()], [warning], [message], or
 #' quietly, depending on argument `signal`.
+#'
+#' @returns
+#' `text`, returned [invisibly][invisible()].
 #'
 #' @seealso
 #' [wrap_text()]

--- a/inst/tinytest/test_create_file_path.R
+++ b/inst/tinytest/test_create_file_path.R
@@ -244,6 +244,5 @@ unlink(x = my_tempdir, recursive = TRUE)
 
 
 ##### Remove objects used in tests #####
-rm(add_date, dir, filenm, filenm_in, # filenm_out,
-   ind_filenm, my_tempdir,
-   my_tempfile)
+rm(add_date, current_date_dmY, current_date_Ymd, dir, filenm, filenm_in,
+   ind_filenm, my_tempdir, my_tempfile, tempdir_basename, tempdir_pattern)

--- a/inst/tinytest/test_create_file_path.R
+++ b/inst/tinytest/test_create_file_path.R
@@ -80,6 +80,22 @@ for(filenm in c("a.txt", "c#c.txt", "d d.txt", "e3f.txt", "g_g.g.txt", "ab.c#"))
   ))
 }
 
+for(filenm_in in c("abcd", "abc.", ".", ".txt", ".html")) {
+  expect_error(create_file_path(filename = filenm_in, dir = my_tempdir,
+                                format_stamp = ""),
+               pattern = "Empty filename or missing extension",
+               fixed = TRUE)
+}
+
+filenm_in <- c("a/a.txt", "b\\b.txt")
+for(ind_filenm in seq_along(filenm_in)) {
+  expect_error(
+    create_file_path(filename = filenm_in[ind_filenm], format_stamp = "",
+                     dir = my_tempdir, add_date = FALSE),
+    pattern = paste0("should not contain '/' or '\\'"),
+    fixed = TRUE)
+}
+
 expect_error(
   create_file_path(filename = "ff .txt", format_stamp = "",
                    dir = my_tempdir, add_date = FALSE),
@@ -128,64 +144,6 @@ expect_true(
                              dir = my_tempdir, add_date = FALSE))
 )
 
-##### dir #####
-# 'directories' might contain a file extension
-expect_true(endsWith(
-  create_file_path(filename = "abc.txt", format_stamp = "",
-                   dir = fs::path(my_tempdir, ".txt"), add_date = FALSE),
-  fs::path(tempdir_basename, "testcreatepath", ".txt", "abc.txt")
-))
-
-expect_warning(
-  expect_true(endsWith(
-    create_file_path(filename = "testfile123.csv", format_stamp = "",
-                     dir = my_tempfile, add_date = FALSE),
-    suffix = fs::path(basename(getwd()), "testfile123.csv"))),
-  pattern = "already exists", fixed = TRUE
-)
-
-##### Warnings #####
-# A warning is issued if the file indicated by the returned path already exists.
-my_tempfile <- fs::path(my_tempdir, "testfile.csv")
-write.table(x = data.frame(a = "a", b = pi), file = my_tempfile)
-expect_warning(
-  expect_true(endsWith(
-    create_file_path(filename = basename(my_tempfile), format_stamp = "",
-                     dir = my_tempdir, add_date = FALSE),
-    suffix = fs::path(tempdir_basename, "testcreatepath", basename(my_tempfile)))),
-  pattern = "File already exists:", strict = TRUE, fixed = TRUE)
-
-##### Check 'filename' #####
-expect_error(create_file_path(dir = my_tempdir),
-             pattern = "argument \"filename\" is missing, with no default",
-             fixed = TRUE)
-expect_error(create_file_path(filename = 123, dir = my_tempdir),
-             pattern = "checkinput::is_character(filename) is not TRUE",
-             fixed = TRUE)
-expect_error(create_file_path(filename = c("abc.txt", "def.txt"), dir = my_tempdir),
-             pattern = "checkinput::is_character(filename) is not TRUE",
-             fixed = TRUE)
-expect_error(create_file_path(filename = "", dir = my_tempdir),
-             pattern = "checkinput::is_character(filename) is not TRUE",
-             fixed = TRUE)
-
-for(filenm_in in c("abcd", "abc.", ".", ".txt", ".html")) {
-  expect_error(create_file_path(filename = filenm_in, dir = my_tempdir,
-                                format_stamp = ""),
-               pattern = "Empty filename or missing extension",
-               fixed = TRUE)
-}
-
-filenm_in <- c("a/a.txt", "b\\b.txt")
-for(ind_filenm in seq_along(filenm_in)) {
-  expect_error(
-    create_file_path(filename = filenm_in[ind_filenm], format_stamp = "",
-                     dir = my_tempdir, add_date = FALSE),
-    pattern = paste0("should not contain '/' or '\\'"),
-    fixed = TRUE)
-}
-
-##### Check 'format_stamp' #####
 expect_error(
   create_file_path(filename = "abc.txt", format_stamp = character(0),
                    dir = my_tempdir, add_date = TRUE),
@@ -204,7 +162,22 @@ expect_error(
   pattern = paste0("checkinput::is_character(format_stamp, allow_empty = TRUE)",
                    " is not TRUE"), fixed = TRUE)
 
-##### Check 'dir' #####
+##### dir #####
+# 'directories' might contain a file extension
+expect_true(endsWith(
+  create_file_path(filename = "abc.txt", format_stamp = "",
+                   dir = fs::path(my_tempdir, ".txt"), add_date = FALSE),
+  fs::path(tempdir_basename, "testcreatepath", ".txt", "abc.txt")
+))
+
+expect_warning(
+  expect_true(endsWith(
+    create_file_path(filename = "testfile123.csv", format_stamp = "",
+                     dir = my_tempfile, add_date = FALSE),
+    suffix = fs::path(basename(getwd()), "testfile123.csv"))),
+  pattern = "already exists", fixed = TRUE
+)
+
 for(dir in list(3, "", character(0), NULL, c("temp_p1", "temp_p2"))) {
   expect_error(
     create_file_path(filename = "abc.txt", dir = dir),
@@ -229,7 +202,35 @@ for(dir in list(paste0(my_tempdir, ".."),
     pattern = "should not end with ' ' or '.'", fixed = TRUE)
 }
 
-##### Check 'add_date' #####
+##### Warnings #####
+# A warning is issued if the file indicated by the returned path already exists.
+my_tempfile <- fs::path(my_tempdir, "testfile.csv")
+write.table(x = data.frame(a = "a", b = pi), file = my_tempfile)
+expect_warning(
+  expect_true(endsWith(
+    create_file_path(filename = basename(my_tempfile), format_stamp = "",
+                     dir = my_tempdir, add_date = FALSE),
+    suffix = fs::path(tempdir_basename, "testcreatepath", basename(my_tempfile)))),
+  pattern = "File already exists:", strict = TRUE, fixed = TRUE)
+
+
+#### Invalid input ####
+
+##### filename #####
+expect_error(create_file_path(dir = my_tempdir),
+             pattern = "argument \"filename\" is missing, with no default",
+             fixed = TRUE)
+expect_error(create_file_path(filename = 123, dir = my_tempdir),
+             pattern = "checkinput::is_character(filename) is not TRUE",
+             fixed = TRUE)
+expect_error(create_file_path(filename = c("abc.txt", "def.txt"), dir = my_tempdir),
+             pattern = "checkinput::is_character(filename) is not TRUE",
+             fixed = TRUE)
+expect_error(create_file_path(filename = "", dir = my_tempdir),
+             pattern = "checkinput::is_character(filename) is not TRUE",
+             fixed = TRUE)
+
+##### add_date #####
 for(add_date in list(1, NA)) {
   expect_error(
     create_file_path(filename = "abc.txt", dir = my_tempdir, add_date = add_date),

--- a/inst/tinytest/test_is_path.R
+++ b/inst/tinytest/test_is_path.R
@@ -6,6 +6,7 @@ warn_Windows_reserved <- "should not contain Windows-reserved names"
 
 
 #### Tests ####
+# NB. These are not allowed as path components but are allowed as filename
 for(Windows_name in c("CON", "PRN", "AUX", "NUL", paste0("COM", 1:9),
                       paste0("LPT", 1:9))) {
   expect_error(is_path(path = fs::path_wd(Windows_name)),
@@ -14,7 +15,7 @@ for(Windows_name in c("CON", "PRN", "AUX", "NUL", paste0("COM", 1:9),
                pattern = warn_Windows_reserved, fixed = TRUE)
 }
 
-# 'COM', 'COM0', 'LPT' and 'LPT0' are allowed
+# 'COM', 'COM0', 'LPT' and 'LPT0' are allowed as filename and as path component
 for(filename in c("COM", "COM0", "LPT", "LPT0")) {
   expect_true(is_path(path = fs::path_wd(paste0(filename, ".txt"))))
 }

--- a/man/check_case.Rd
+++ b/man/check_case.Rd
@@ -21,13 +21,11 @@ values are present. The return is \link{invisible}.
 \description{
 Check for values that differ only in their case
 }
-\section{Side effects}{
-
+\details{
 Values in \code{x} that only differ from each other in their case generate an
 \link[=stop]{error}, \link{warning}, or \link{message} if \code{signal} is \code{error}, \code{warning}, or
 \code{message}, respectively. Values are silently returned if \code{signal} is \code{quiet}.
 }
-
 \section{Notes}{
 
 The sorting order in the result depends on the used \link[=locales]{locale} (see

--- a/man/create_dir.Rd
+++ b/man/create_dir.Rd
@@ -4,14 +4,13 @@
 \alias{create_dir}
 \title{Create a directory}
 \usage{
-create_dir(dir = fs::path_wd("output"), add_date = TRUE)
+create_dir(dir = fs::path(".", "output"), add_date = TRUE)
 }
 \arguments{
-\item{dir}{Non-empty \link[checkinput:is_character]{character string}
+\item{dir}{\link[checkinput:is_character]{Character string}
 containing a \link[=is_path]{valid path} to a directory that should be created if
-it does not yet exist. \code{\link[fs:path]{fs::path()}} ensures the correct
-(\link[=.Platform]{platform}-dependent) file separator is used to indicate
-subdirectories and the dot (\code{"."}) indicates the \link[=getwd]{working directory},
+it does not yet exist. \code{\link[fs:path]{fs::path()}} adds file separators and the dot (\code{"."})
+indicates the \link[=getwd]{working directory},
 such that by default a subdirectory with the current date in the
 \link[=strftime]{format} \code{YYYY_mm_dd} in directory \code{output} below the working
 directory is created.}
@@ -23,15 +22,13 @@ current date in the \link[=strftime]{format} \code{YYYY_mm_dd}?}
 A character string with the absolute \link[=normalizePath]{normalized} path to
 the requested directory, returned \link[=invisible]{invisibly}. The
 \link[=getwd]{working directory} is returned if an attempt to create a directory
-fails, with a warning.
+fails, with a warning. This happens if \code{dir} points to an existing file
+instead of an directory.
 }
 \description{
 Create a directory if it does not yet exist.
 }
 \details{
-If creating the directory fails, the working directory is returned instead.
-This happens if \code{dir} points to an existing file instead of an directory.
-
 The absolute \link[=normalizePath]{normalised} path is returned such that the
 returned path still works if the \link[=getwd]{working directory} changes. On
 case-insensitive file systems (e.g., Windows and macOS), normalization

--- a/man/create_file_path.Rd
+++ b/man/create_file_path.Rd
@@ -21,11 +21,10 @@ the stamp to be added in front of the file name. No stamp is added if
 treated as part of the filename, such that the same restrictions apply, see
 \code{Details}.}
 
-\item{dir}{Non-empty \link[checkinput:is_character]{character string}
+\item{dir}{\link[checkinput:is_character]{Character string}
 containing a \link[=is_path]{valid path} to a directory that should be created if
-it does not yet exist. \code{\link[fs:path]{fs::path()}} ensures the correct
-(\link[=.Platform]{platform}-dependent) file separator is used to indicate
-subdirectories and the dot (\code{"."}) indicates the \link[=getwd]{working directory},
+it does not yet exist. \code{\link[fs:path]{fs::path()}} adds file separators and the dot (\code{"."})
+indicates the \link[=getwd]{working directory},
 such that by default a subdirectory with the current date in the
 \link[=strftime]{format} \code{YYYY_mm_dd} in directory \code{output} below the working
 directory is created.}

--- a/man/create_tempdir.Rd
+++ b/man/create_tempdir.Rd
@@ -20,9 +20,9 @@ Create a temporary directory that can safely be removed.
 }
 \details{
 \code{subdir} is created inside \code{\link[=tempdir]{tempdir()}} and an error is thrown if it already
-exists. This ensures that \link[=unlink]{removing} the created directory does not
-remove files that are still needed by other processes (see \verb{Usage in practice}
-below).
+exists or creating the directory fails. This ensures that \link[=unlink]{removing}
+the created directory does not remove files that are still needed by other
+processes (see \verb{Usage in practice} below).
 
 It is possible to create subdirectories inside a not-yet existing directory
 (e.g., to create \verb{<tempdir>/output/outputsub} if \verb{<tempdir>/output} does not
@@ -30,11 +30,8 @@ yet exist.
 }
 \section{Side effects}{
 
-The requested temporary directory is [created][dir.create)()] if does not yet
-exist. An error is thrown if the directory already exists or creating the
-directory fails.
-
-[dir.create)()]: R:dir.create)()
+The temporary directory indicated by the returned path is
+\link[=dir.create]{created} if does not yet exist.
 }
 
 \section{Usage in practice}{

--- a/man/is_path.Rd
+++ b/man/is_path.Rd
@@ -34,7 +34,8 @@ these names, or these names followed by an extension.
 used instead (see \code{\link[=create_tempdir]{create_tempdir()}}).
 }
 
-Furthermore, if \code{path} contains a file extension, the part after the last
+Furthermore, if \code{path} contains a file extension or compression extension,
+the part after the last
 slash is considered the filename, which should adhere to the same
 restrictions as the path, and in addition should \strong{not} contain \code{:} nor
 start with a space.
@@ -45,7 +46,7 @@ that would lead to a mismatch between the created directory and the returned
 path because they are silently removed in Windows; and words that are
 reserved names in Windows.
 
-\code{path} \strong{not} necessarily has to contain a file separator (i.e., \code{/} or
+\code{path} does \strong{not} have to contain a file separator (i.e., \code{/} or
 \verb{\\\\}), such that \code{is_path()} can be used to check that input to \code{\link[fs:path]{fs::path()}}
 only contains allowed characters. Repeated file separators (e.g., \verb{//} or
 \verb{\\\\\\\\}) are treated as single separators, with a warning.
@@ -105,7 +106,7 @@ try(is_path(fs::path_wd("ab|cd.txt")))
 paths), \code{\link[=create_dir]{create_dir()}} to create a directory if it does not yet exist,
 \code{\link[=get_file_path]{get_file_path()}} to check if a file exists and is a unique match to a pattern
 
-\code{fs::path_sanitize()} to \emph{remove} invalid characters from potential paths.
+\code{fs::path_sanitize()} to \strong{remove} invalid characters from potential paths.
 
 Other functions to handle paths and directories:
 \code{\link[=create_dir]{create_dir()}},

--- a/man/signal_text.Rd
+++ b/man/signal_text.Rd
@@ -32,13 +32,10 @@ Signal a text to the user through an error, warning, or message.
 zero-length input and input with length larger than one better than
 \code{\link[=message]{message()}} etc. that use \code{\link[=paste0]{paste0()}}, see the \code{Examples}. Call \code{\link[=vect_to_char]{vect_to_char()}}
 beforehand on \code{text} to control rounding and wrapping, see the last example.
-}
-\section{Side effects}{
 
 \code{text} is signalled through an \link[=stop]{error}, \link{warning}, \link{message}, or
 quietly, depending on argument \code{signal}.
 }
-
 \examples{
 test_text <- c("Some text", "Some other text")
 try(signal_text(text = test_text, signal = "error"))


### PR DESCRIPTION
Use `fs::path()` instead of `fs::path_wd()` for default. Emitting errors is not a side-effect.