### PR TITLE
Reflect updates to `checkinput::is_path()`.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,10 @@
 # progutils 0.4.0
 
 ### Breaking changes
-- `is_path()`: moved to package `checkinput`.
+- `is_path()`: move to package `checkinput`. Rename argument `path` to `x`.
+  Adjusted to warn and return `FALSE` instead of throwing an error if `path` is
+  not a valid path. Not allow filenames to start with a hyphen. Not warn about
+  duplicated file separators or pointing to `tempdir()`.
 
 
 # progutils 0.3.0

--- a/R/create_dir.R
+++ b/R/create_dir.R
@@ -78,8 +78,8 @@
 #'
 #' @export
 create_dir <- function(dir = fs::path(".", "output"), add_date = TRUE) {
-  stopifnot(checkinput::is_logical(add_date))
-  checkinput::is_path(dir)
+  stopifnot(checkinput::is_character(dir), checkinput::is_path(dir),
+            checkinput::is_logical(add_date))
 
   if(add_date) {
     dir <- fs::path(dir, format(Sys.time(), format = "%Y_%m_%d"))

--- a/R/create_file_path.R
+++ b/R/create_file_path.R
@@ -71,15 +71,15 @@
 #' @export
 create_file_path <- function(filename, format_stamp = "%Y_%m_%d_%H_%M_%S",
                              dir = fs::path_wd("output"), add_date = TRUE) {
-  stopifnot(checkinput::is_character(filename),
+  stopifnot(checkinput::is_character(filename), checkinput::is_path(filename),
             checkinput::is_character(format_stamp, allow_empty = TRUE),
+            checkinput::is_character(dir), checkinput::is_path(dir),
             checkinput::is_logical(add_date))
-  checkinput::is_path(path = dir)
 
   filename_no_ext <- fs::path_ext_remove(path = filename)
   file_ext <- fs::path_ext(path = filename)
-  if(!nzchar(filename_no_ext) || !nzchar(file_ext) ||
-     length(filename_no_ext) == 0L || length(file_ext) == 0L) {
+  if(length(filename_no_ext) == 0L || !nzchar(filename_no_ext) ||
+     length(file_ext) == 0L || !nzchar(file_ext)) {
     stop("Empty filename or missing extension:\n", filename)
   }
 
@@ -95,7 +95,7 @@ create_file_path <- function(filename, format_stamp = "%Y_%m_%d_%H_%M_%S",
 
   file_path <- fs::path(create_dir(dir = dir, add_date = add_date), filename)
   file_path <- normalizePath(path = file_path, winslash = "/", mustWork = FALSE)
-  is_valid_file_path <- try(expr = checkinput::is_path(path = file_path), silent = TRUE)
+  is_valid_file_path <- try(expr = checkinput::is_path(file_path), silent = TRUE)
   if(inherits(x = is_valid_file_path, what = "try-error")) {
     stop("No path created: ", attr(is_valid_file_path, "condition")$message)
   }

--- a/R/create_tempdir.R
+++ b/R/create_tempdir.R
@@ -57,8 +57,7 @@
 #'
 #' @export
 create_tempdir <- function(subdir = "subdir") {
-  stopifnot(checkinput::is_character(subdir))
-  checkinput::is_path(path = subdir)
+  stopifnot(checkinput::is_character(subdir), checkinput::is_path(subdir))
   subdir_target <- normalizePath(path = fs::path(tempdir(), subdir),
                                  winslash = "/", mustWork = FALSE)
   tempdir_normalised <- normalizePath(tempdir(), winslash = "/", mustWork = FALSE)

--- a/R/get_file_path.R
+++ b/R/get_file_path.R
@@ -73,7 +73,8 @@
 #'
 #' @export
 get_file_path <- function(dir = ".", pattern, ignore_case = TRUE, quietly = FALSE) {
-  stopifnot(checkinput::is_character(dir), checkinput::is_character(pattern),
+  stopifnot(checkinput::is_character(dir), checkinput::is_path(dir),
+            checkinput::is_character(pattern),
             checkinput::is_logical(ignore_case), checkinput::is_logical(quietly))
 
   dir <- normalizePath(dir, winslash = "/", mustWork = FALSE)

--- a/inst/tinytest/test_create_dir.R
+++ b/inst/tinytest/test_create_dir.R
@@ -47,6 +47,10 @@ my_tempfile <- fs::path(my_tempdir, "test_df.csv")
 # Write csv-file, modified from example in help(write.table)
 write.table(x = data.frame(a = "a", b = pi), file = my_tempfile)
 
+pattern_temp <- file.path(tempdir_basename, "testcreatedir", "temp")
+pattern_subtemp <- file.path(pattern_temp, "subtemp")
+
+
 # without date directory
 dir <- fs::path(my_tempdir, "temp_subdirF_dateF")
 expected_path <- dir
@@ -76,7 +80,7 @@ expect_true(dir.exists(expected_path))
 expect_true(endsWith(
   dir_date,
   suffix = fs::path(tempdir_basename, "testcreatedir", "temp_subdirF_dateT",
-                     format(Sys.time(), format = "%Y_%m_%d"))
+                    format(Sys.time(), format = "%Y_%m_%d"))
 ))
 
 # with subdirectories, with date directory
@@ -89,50 +93,58 @@ expect_true(dir.exists(expected_path))
 expect_true(endsWith(
   dir_subdir_date,
   suffix = fs::path(tempdir_basename, "testcreatedir", "temp_subdirT_dateT", "subdir",
-                     format(Sys.time(), format = "%Y_%m_%d"))
+                    format(Sys.time(), format = "%Y_%m_%d"))
 ))
 
 # Checks on input to 'dir'
 for(dir in list(3, "", character(0), NULL, c("temp_p1", "temp_p2"))) {
   expect_error(
     create_dir(dir = dir),
-    pattern = "is_character(path) is not TRUE", fixed = TRUE)
+    pattern = "is_character(dir) is not TRUE", fixed = TRUE)
 }
 
 for(dir in list(fs::path(my_tempdir, "temp", "."),
                 fs::path(my_tempdir, "temp."),
                 fs::path(my_tempdir, "temp.", "subtemp"))) {
-  expect_error(
-    create_dir(dir = dir),
-    pattern = "'dir' should not end with ' ' or '.'", fixed = TRUE)
+  expect_warning(
+    expect_error(
+      create_dir(dir = dir),
+      pattern = "is_path(dir) is not TRUE", fixed = TRUE),
+    pattern = "Components of 'dir' should not end with ' ' or '.'",
+    fixed = TRUE, strict = TRUE)
 }
 
 # Notes:
 # - Need paste0() because fs::path() removes trailing slashes.
-# - Need to use '\\\\': '\\' would test for '\'.
-expect_warning(
-  create_dir(dir = paste0(fs::path(my_tempdir, "temp"), "//")),
-  pattern = "Repeated '/' or '\\\\'", fixed = TRUE)
+expect_silent(expect_true(
+  grepl(pattern = pattern_temp,
+        x = create_dir(dir = paste0(fs::path(my_tempdir, "temp"), "//")))
+))
 
-expect_warning(
-  create_dir(dir = paste0(fs::path(my_tempdir, "temp"), "//subtemp")),
-  pattern = "Repeated '/' or '\\\\'", fixed = TRUE)
+expect_silent(expect_true(
+  grepl(pattern = pattern_subtemp,
+        x = create_dir(dir = paste0(fs::path(my_tempdir, "temp"), "//subtemp")))
+))
 
-expect_warning(
-  create_dir(dir = paste0(fs::path(my_tempdir), "\\\\")),
-  pattern = "Repeated '/' or '\\\\'", fixed = TRUE)
+expect_silent(expect_true(
+  grepl(pattern = dirname(pattern_temp),
+        x = create_dir(dir = paste0(fs::path(my_tempdir), "\\\\")))
+))
 
-expect_warning(
-  create_dir(dir = paste0(fs::path(my_tempdir), "\\\\subtemp")),
-  pattern = "Repeated '/' or '\\\\'", fixed = TRUE)
+expect_silent(expect_true(
+  grepl(pattern = pattern_temp,
+        x = create_dir(dir = paste0(fs::path(my_tempdir), "\\\\temp")))
+))
 
-expect_warning(
-  create_dir(dir = paste0(my_tempdir, "\\\\")),
-  pattern = "Repeated '/' or '\\\\'", fixed = TRUE)
+expect_silent(expect_true(
+  grepl(pattern = dirname(pattern_temp),
+        x = create_dir(dir = paste0(my_tempdir, "\\\\")))
+))
 
-expect_warning(
-  create_dir(dir = paste0(my_tempdir, "\\\\subtemp")),
-  pattern = "Repeated '/' or '\\\\'", fixed = TRUE)
+expect_silent(expect_true(
+  grepl(pattern = pattern_temp,
+        x = create_dir(dir = paste0(my_tempdir, "\\\\temp")))
+))
 
 # NB. 'dir' equal to '.' or '..' can be used to denote the current working
 # directory and its parent directory, respectively. By default, this will add
@@ -145,9 +157,12 @@ for(dir in list(fs::path(my_tempdir, " "),
                 fs::path(my_tempdir, ".."),
                 fs::path(my_tempdir, "temp."),
                 fs::path(my_tempdir, "temp.", "subtemp"))) {
-  expect_error(
-    create_dir(dir = dir),
-    pattern = "'dir' should not end with ' ' or '.'", fixed = TRUE)
+  expect_warning(
+    expect_error(
+      create_dir(dir = dir),
+      pattern = "checkinput::is_path(dir) is not TRUE", fixed = TRUE),
+    pattern = "Components of 'dir' should not end with ' ' or '.'",
+    fixed = TRUE, strict = TRUE)
 }
 
 # Working directory is returned if 'dir' points to a file instead of a directory
@@ -155,7 +170,7 @@ expect_warning(
   expect_true(endsWith(
     create_dir(dir = my_tempfile, add_date = FALSE),
     suffix = basename(getwd())
-    )),
+  )),
   pattern = "Attempt to create directory failed", strict = TRUE, fixed = TRUE)
 
 # Checks on input to 'add_date'
@@ -172,4 +187,5 @@ unlink(my_tempdir, recursive = TRUE)
 
 #### Remove objects used in tests ####
 rm(add_date, dir, dir_no_date, dir_no_date_v2, dir_date, dir_subdir_date,
-   expected_path, my_tempdir, my_tempfile, tempdir_basename)
+   expected_path, my_tempdir, my_tempfile, pattern_temp, pattern_subtemp,
+   tempdir_basename)

--- a/inst/tinytest/test_create_file_path.R
+++ b/inst/tinytest/test_create_file_path.R
@@ -80,12 +80,19 @@ for(filenm in c("a.txt", "c#c.txt", "d d.txt", "e3f.txt", "g_g.g.txt", "ab.c#"))
   ))
 }
 
-for(filenm_in in c("abcd", "abc.", ".", ".txt", ".html")) {
+for(filenm_in in c("abcd", ".", ".txt", ".html")) {
   expect_error(create_file_path(filename = filenm_in, dir = my_tempdir,
                                 format_stamp = ""),
                pattern = "Empty filename or missing extension",
                fixed = TRUE)
 }
+
+expect_warning(
+  expect_error(
+    create_file_path(filename = "abc.", dir = my_tempdir, format_stamp = ""),
+    pattern = "is_path(filename) is not TRUE", fixed = TRUE),
+  pattern = "Components of 'filename' should not end with ' ' or '.'",
+  strict = TRUE, fixed = TRUE)
 
 filenm_in <- c("a/a.txt", "b\\b.txt")
 for(ind_filenm in seq_along(filenm_in)) {
@@ -96,17 +103,21 @@ for(ind_filenm in seq_along(filenm_in)) {
     fixed = TRUE)
 }
 
-expect_error(
-  create_file_path(filename = "ff .txt", format_stamp = "",
-                   dir = my_tempdir, add_date = FALSE),
-  pattern = "'filename' should not end with ' ' or '.'", fixed = TRUE)
+expect_warning(
+  expect_error(
+    create_file_path(filename = "ff .txt", format_stamp = "",
+                     dir = my_tempdir, add_date = FALSE),
+    pattern = "is_path(filename) is not TRUE", fixed = TRUE),
+  pattern = "'filename' should not end with ' ' or '.'", strict = TRUE, fixed = TRUE)
 
-# No error message specified: on Windows with R 4.6.0 the error message is
+# No warning message specified: on Windows with R 4.6.0 the warning message is
 # '"'filename' should not end with ' ' or '.'"', but on Windows with R 4.1.0 the
 # error message is "Empty filename or missing extension"
-expect_error(
-  create_file_path(filename = "ff..txt", format_stamp = "",
-                   dir = my_tempdir, add_date = FALSE))
+expect_warning(
+  expect_error(
+    create_file_path(filename = "ff..txt", format_stamp = "", dir = my_tempdir,
+                     add_date = FALSE))
+)
 
 ##### format_stamp #####
 # Characters in 'format_stamp' not part of a conversion specification in
@@ -181,14 +192,12 @@ expect_warning(
 for(dir in list(3, "", character(0), NULL, c("temp_p1", "temp_p2"))) {
   expect_error(
     create_file_path(filename = "abc.txt", dir = dir),
-    pattern = "is_character(path) is not TRUE", fixed = TRUE)
+    pattern = "is_character(dir) is not TRUE", fixed = TRUE)
 }
 
 for(dir in list(paste0(my_tempdir, "//"),
                 paste0(my_tempdir, "//temp_p1"))) {
-  expect_warning(
-    create_file_path(filename = "abc.txt", dir = dir),
-    pattern = "Repeated '/' or '\\\\'", fixed = TRUE)
+  expect_silent(create_file_path(filename = "abc.txt", dir = dir))
 }
 
 for(dir in list(paste0(my_tempdir, ".."),
@@ -197,9 +206,11 @@ for(dir in list(paste0(my_tempdir, ".."),
                 fs::path(my_tempdir, "."),
                 paste0(my_tempdir, ". "),
                 paste0(my_tempdir, "temp_p1 "))) {
-  expect_error(
-    create_file_path(filename = "abc.txt", dir = dir),
-    pattern = "should not end with ' ' or '.'", fixed = TRUE)
+  expect_warning(
+    expect_error(
+      create_file_path(filename = "abc.txt", dir = dir),
+      pattern = "is_path(dir) is not TRUE", fixed = TRUE),
+    pattern = "should not end with ' ' or '.'", strict = TRUE, fixed = TRUE)
 }
 
 ##### Warnings #####

--- a/inst/tinytest/test_create_tempdir.R
+++ b/inst/tinytest/test_create_tempdir.R
@@ -53,21 +53,19 @@ for(ind_subdir in seq_along(subdir_in)) {
   ))
 }
 
-expect_warning(
+expect_silent(
   expect_true(endsWith(
     create_tempdir(subdir = "\\temp_p5"),
     suffix = fs::path(basename(my_tempdir), "temp_p5")
-  )),
-  pattern = "Repeated '/' or '\\\\' in 'subdir' will be ignored",
-  strict = TRUE, fixed = TRUE)
+  ))
+)
 
-expect_warning(
+expect_silent(
   expect_true(endsWith(
     create_tempdir(subdir = "/temp_p6"),
     suffix = fs::path(basename(my_tempdir), "temp_p6")
-  )),
-  pattern = "Repeated '/' or '\\\\' in 'subdir' will be ignored",
-  strict = TRUE, fixed = TRUE)
+  ))
+)
 
 expect_error(
   create_tempdir(subdir = "."),
@@ -78,9 +76,11 @@ expect_error(
   pattern = "would write above 'tempdir()'", fixed = TRUE)
 
 for(subdir in list("temp_p7.", "temp_p8 ")) {
-  expect_error(
-    create_tempdir(subdir = subdir),
-    pattern = "should not end with ' ' or '.'", fixed = TRUE)
+  expect_warning(
+    expect_error(
+      create_tempdir(subdir = subdir),
+      pattern = "is_path(subdir) is not TRUE", fixed = TRUE),
+    pattern = "should not end with ' ' or '.'", strict = TRUE, fixed = TRUE)
 }
 
 


### PR DESCRIPTION
### Breaking changes
- `is_path()`: move to package `checkinput`. Rename argument `path` to `x`. Adjusted to warn and return `FALSE` instead of throwing an error if `path` is not a valid path. Not allow filenames to start with a hyphen. Not warn about duplicated file separators or pointing to `tempdir()`.