### PR TITLE
progutils 0.5.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: progutils
 Title: Programming Utilities
-Version: 0.4.0
+Version: 0.5.0
 Authors@R: 
     person("Jesse", "Alderliesten", email = "jessealderliesten@hotmail.com",
     role = c("aut", "cre"), comment = c(ORCID = "0000-0003-1132-4310"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+# progutils 0.5.0
+
+### Breaking changes
+- `create_dir()`: throw an error instead of returning the working directory if
+  creating the directory fails: returning the working directory is an unsafe
+  fall-back because the reasonable assumption that the newly-created directory
+  did not yet exist before `create_dir()` was called then could lead to deleting
+  the working directory.
+- `create_file_path()` and `get_file_path()`: no need to warn about an
+  already-existing directory with a path equal to a file path or about an
+  already-existing file with a path equal to a directory path.
+
+
 # progutils 0.4.0
 
 ### Breaking changes

--- a/R/create_dir.R
+++ b/R/create_dir.R
@@ -14,20 +14,17 @@
 #' current date in the [format][strftime()] `YYYY_mm_dd`?
 #'
 #' @details
-#' The absolute [normalised][normalizePath()] path is returned such that the
+#' The [absolute normalised][fs::path_abs()] path is returned such that the
 #' returned path still works if the [working directory][getwd()] changes. On
 #' case-insensitive file systems (e.g., Windows and macOS), normalization
 #' adjusts the case to match case-insensitive names of directories that are
-#' already present (see the `Examples`). `"/"` instead of `"\\"` is used as
-#' [winslash][normalizePath()] during normalisation, such that the returned path
-#' can be used in Windows' file system.
+#' already present (see the `Examples`).
 #'
 #' @returns
-#' A character string with the absolute [normalized][normalizePath()] path to
-#' the requested directory, returned [invisibly][invisible]. The
-#' [working directory][getwd()] is returned if an attempt to create a directory
-#' fails, with a warning. This happens if `dir` points to an existing file
-#' instead of an directory.
+#' A character string with the [absolute normalized][fs::path_abs()] path to
+#' the requested directory, returned [invisibly][invisible]. An error is thrown
+#' if the attempt to create a directory fails. This happens if `dir` points to
+#' an existing file instead of an directory.
 #'
 #' @section Side effects:
 #' The directory indicated by the returned path is [created][create_dir()] if it
@@ -38,7 +35,7 @@
 #' [create_file_path()] to create a file path and creating the indicated
 #' directory if it does not yet exist; [create_tempdir()] for a safe way
 #' to create temporary directories; [checkinput::is_path()] and references there about file
-#' paths and directories; [dir.exists()] and [dir.create()] used by this
+#' paths and directories; [fs::dir_exists()] and [dir.create()] used by this
 #' function; [get_file_path()] to check if a file exists and is a unique match to
 #' a pattern.
 #'
@@ -51,7 +48,7 @@
 #' # Create directory 'dir_one' inside this temporary directory
 #' res_dir_one <- create_dir(dir = fs::path(my_tempdir, "dir_one"),
 #'                           add_date = FALSE)
-#' dir.exists(res_dir_one) # TRUE
+#' fs::dir_exists(res_dir_one) # TRUE
 #'
 #' # An attempt to create a directory that already exists does not change any
 #' # directory and the same directory is returned.
@@ -70,7 +67,7 @@
 #' # Create directory 'dir_two' with a subdirectory containing the current date
 #' res_dir_two <- create_dir(dir = fs::path(my_tempdir, "dir_two"),
 #'                           add_date = TRUE)
-#' dir.exists(res_dir_two) # TRUE
+#' fs::dir_exists(res_dir_two) # TRUE
 #'
 #' # Cleaning up
 #' unlink(dirname(res_dir_one), recursive = TRUE)
@@ -85,26 +82,15 @@ create_dir <- function(dir = fs::path(".", "output"), add_date = TRUE) {
     dir <- fs::path(dir, format(Sys.time(), format = "%Y_%m_%d"))
   }
 
-  dir <- normalizePath(dir, winslash = "/", mustWork = FALSE)
+  dir <- fs::path_abs(dir)
 
-  # dir.exists() returns FALSE if 'dir' is a file instead of a directory.
-  if(!dir.exists(dir)) {
-    # Notes:
-    # - This branch is only used if the directory did not yet exist as directory,
-    #   so it is not a problem that dir.create() returns FALSE if a directory
-    #   already exists. However, the path can already exist as a file: then the
-    #   attempt to create it as a directory will fail (indicated by a warning)
-    #   and the working directory will be used instead (indicated by an
-    #   additional warning).
-    # - Using 'recursive = TRUE' to allow creation of subdirectories inside a
-    #   not-yet existing directory (e.g., creating './output/<date>' if
-    #   './output' does not yet exist).
-    if(!dir.create(path = dir, recursive = TRUE)) {
-      warning("Attempt to create directory failed (perhaps it points to an",
-              " existing file?):\n", dir,
-              "\nReturning the working directory instead:\n", getwd())
-      dir <- normalizePath(getwd(), winslash = "/", mustWork = NA)
-    }
+  # fs::dir_exists() returns FALSE if 'dir' is a file instead of a directory but
+  # fs::dir_create() then throws an informative error.
+  if(!fs::dir_exists(dir)) {
+    # Using 'recurse = TRUE' to allow creation of subdirectories inside a
+    # not-yet existing directory (e.g., creating './output/<date>' if './output'
+    # does not yet exist).
+    fs::dir_create(path = dir, recurse = TRUE)
   }
 
   invisible(dir)

--- a/R/create_file_path.R
+++ b/R/create_file_path.R
@@ -19,10 +19,8 @@
 #' character until the end of the file name) and should **not** contain slashes
 #' or backslashes: use `dir` to indicate subdirectories.
 #'
-#' The absolute [normalised][normalizePath()] path is returned such that the
-#' returned path still works if the [working directory][getwd()] changes. `"/"`
-#' instead of `"\\"` is used as argument [winslash][normalizePath()] such that
-#' the returned path can be used in Windows' file system.
+#' The [absolute normalised][fs::path_abs()] path is returned such that the
+#' returned path still works if the [working directory][getwd()] changes.
 #'
 #' A warning is issued if the **file** indicated by the returned path already
 #' exists. To prevent this when creating files in quick succession, use `"%OSn"`
@@ -37,14 +35,14 @@
 #' [checkinput::is_path()] to check if a path is valid,
 #' [get_file_path()] to check if a file exists and is a unique match to a pattern,
 #' [fs::path()] to construct file paths in a platform-independent way,
-#' [normalizePath()] to create absolute normalised paths,
+#' [fs::path_abs()] to create absolute normalised paths,
 #' [create_dir()] to create a directory if it does not yet exist
 #'
 #' @family functions to handle paths and directories
 #'
 #' @examples
 #' # Use a temporary directory to not write in the user's directory
-#' my_tempdir <- normalizePath(path = fs::path(tempdir(), "subdir"),
+#' my_tempdir <- fs::path_abs(path = fs::path(tempdir(), "subdir"),
 #'                             winslash = "/", mustWork = FALSE)
 #'
 #' (create_file_path(filename = "abc.txt", format_stamp = "",
@@ -94,19 +92,14 @@ create_file_path <- function(filename, format_stamp = "%Y_%m_%d_%H_%M_%S",
   }
 
   file_path <- fs::path(create_dir(dir = dir, add_date = add_date), filename)
-  file_path <- normalizePath(path = file_path, winslash = "/", mustWork = FALSE)
+  file_path <- fs::path_abs(path = file_path)
   is_valid_file_path <- try(expr = checkinput::is_path(file_path), silent = TRUE)
   if(inherits(x = is_valid_file_path, what = "try-error")) {
     stop("No path created: ", attr(is_valid_file_path, "condition")$message)
   }
 
-  if(file.exists(file_path)) {
-    if(dir.exists(file_path)) {
-      warning(paste0("Path already exists but points to a directory, not a file:\n",
-                     file_path))
-    } else {
-      warning(paste0("File already exists:\n", file_path))
-    }
+  if(fs::is_file(file_path)) {
+    warning("File already exists:\n", file_path)
   }
   invisible(file_path)
 }

--- a/R/create_file_path.R
+++ b/R/create_file_path.R
@@ -42,8 +42,7 @@
 #'
 #' @examples
 #' # Use a temporary directory to not write in the user's directory
-#' my_tempdir <- fs::path_abs(path = fs::path(tempdir(), "subdir"),
-#'                             winslash = "/", mustWork = FALSE)
+#' my_tempdir <- fs::path_abs(path = fs::path(tempdir(), "subdir"))
 #'
 #' (create_file_path(filename = "abc.txt", format_stamp = "",
 #'                   dir = my_tempdir, add_date = TRUE))

--- a/R/create_tempdir.R
+++ b/R/create_tempdir.R
@@ -17,7 +17,7 @@
 #' yet exist.
 #'
 #' @returns
-#' The [normalized][normalizePath()] path to the created temporary directory,
+#' The [absolute normalized][fs::path_abs()] path to the created temporary directory,
 #' returned [invisibly][invisible].
 #'
 #' @section Side effects:
@@ -58,9 +58,8 @@
 #' @export
 create_tempdir <- function(subdir = "subdir") {
   stopifnot(checkinput::is_character(subdir), checkinput::is_path(subdir))
-  subdir_target <- normalizePath(path = fs::path(tempdir(), subdir),
-                                 winslash = "/", mustWork = FALSE)
-  tempdir_normalised <- normalizePath(tempdir(), winslash = "/", mustWork = FALSE)
+  subdir_target <- fs::path_abs(path = fs::path(tempdir(), subdir))
+  tempdir_normalised <- fs::path_abs(tempdir())
   if(!grepl(pattern = basename(tempdir()), x = subdir_target, fixed = TRUE)) {
     stop("Using ", paste_quoted(subdir),
          " as 'subdir' would write above 'tempdir()' which is not safe: ",
@@ -73,8 +72,9 @@ create_tempdir <- function(subdir = "subdir") {
          tempdir_normalised)
   }
 
-  # dir.exists() returns FALSE if 'subdir_target' is a file instead of a directory.
-  if(!dir.exists(subdir_target)) {
+  # fs::dir_exists() returns FALSE if 'subdir_target' is a file instead of a
+  # directory.
+  if(!fs::dir_exists(subdir_target)) {
     # Notes:
     # - This branch is only used if the directory did not yet exist as directory,
     #   so it is not a problem that dir.create() returns FALSE if a directory
@@ -88,8 +88,8 @@ create_tempdir <- function(subdir = "subdir") {
            subdir_target)
     }
   } else {
-    stop("Temporary directory already exists: change 'subdir' ('", subdir,
-         "'):\n", subdir_target)
+    stop("Temporary directory already exists: change 'subdir' (",
+         paste_quoted(subdir), "):\n", subdir_target)
   }
   invisible(subdir_target)
 }

--- a/R/get_file_path.R
+++ b/R/get_file_path.R
@@ -19,13 +19,11 @@
 #' In contrast to the default of [list.files()], `get_file_path()` also finds
 #' 'hidden' files, i.e., files with names that start with a dot.
 #'
-#' Paths will be [normalized][normalizePath()] to ensure they still work if the
-#' [working directory][getwd()] changes. `"/"` instead of `"\\"` is
-#' used as argument [winslash][normalizePath()] such that the returned path can
-#' be used in Windows' file system.
+#' Paths will be [normalized][fs::path_abs()] to ensure they still work if the
+#' [working directory][getwd()] changes.
 #'
 #' @returns
-#' A character string with the [normalized][normalizePath()] path to the file
+#' A character string with the [absolute normalized][fs::path_abs()] path to the file
 #' with a name matching `pattern` if there is exactly one such file in directory
 #' `dir`. Otherwise an error is thrown. Use [basename()] on the result to obtain
 #' the filename itself.
@@ -38,7 +36,7 @@
 #' [file.info()] and [file.access()] to extract information about files or
 #' directories;
 #' [fs::path()] to construct file paths in a platform-independent way;
-#' [normalizePath()] to create absolute paths.
+#' [fs::path_abs()] to create absolute paths.
 #'
 #' @family functions to handle paths and directories
 #' @family functions to check equality
@@ -77,20 +75,16 @@ get_file_path <- function(dir = ".", pattern, ignore_case = TRUE, quietly = FALS
             checkinput::is_character(pattern),
             checkinput::is_logical(ignore_case), checkinput::is_logical(quietly))
 
-  dir <- normalizePath(dir, winslash = "/", mustWork = FALSE)
-  if(!dir.exists(dir)) {
-    if(file.exists(dir)) {
-      stop("The path in 'dir' ('", dir,
-           "') points to a file but should point to a directory!")
-    } else {
-      stop("'", dir, "' does not exist!")
-    }
+  dir <- fs::path_abs(dir)
+  if(!fs::dir_exists(dir)) {
+    stop("Directory does not exist:\n", paste_quoted(dir))
   }
 
-  files_present <- normalizePath(
+  files_present <- fs::path_abs(
     list.files(path = dir, pattern = pattern, all.files = TRUE,
-               full.names = TRUE, ignore.case = ignore_case),
-    winslash = "/", mustWork = FALSE)
+               full.names = TRUE, ignore.case = ignore_case)
+  )
+
   # 'list.files()' also returns directories (even though 'include.dirs' is FALSE
   # by default) because 'recursive' is also FALSE.
   if(length(files_present) > 0L) {

--- a/inst/tinytest/test_create_dir.R
+++ b/inst/tinytest/test_create_dir.R
@@ -2,13 +2,12 @@ tinytest::report_side_effects()
 
 
 #### Test the examples ####
-my_tempdir <- normalizePath(path = fs::path(tempdir(), "testcreatedir"),
-                            winslash = "/", mustWork = FALSE)
+my_tempdir <- fs::path_abs(path = fs::path(tempdir(), "testcreatedir"))
 tempdir_basename <- basename(tempdir())
 
 res_dir_one <- create_dir(dir = fs::path(my_tempdir, "dir_one"),
                           add_date = FALSE)
-expect_true(dir.exists(res_dir_one))
+expect_true(fs::dir_exists(res_dir_one))
 
 res_dir_one_v2 <- create_dir(dir = fs::path(my_tempdir, "dir_one"),
                              add_date = FALSE)
@@ -31,7 +30,7 @@ create_dir(dir = fs::path(my_tempdir, "dir_ONE"), add_date = FALSE)
 
 res_dir_two <- create_dir(dir = fs::path(my_tempdir, "dir_two"),
                           add_date = TRUE)
-expect_true(dir.exists(res_dir_two))
+expect_true(fs::dir_exists(res_dir_two))
 
 # Cleaning up
 unlink(dirname(res_dir_one), recursive = TRUE)
@@ -39,25 +38,24 @@ rm(my_tempdir, res_dir_one, res_dir_one_v2, res_dir_two, tempdir_basename)
 
 
 #### Tests ####
-my_tempdir <- normalizePath(path = fs::path(tempdir(), "testcreatedir"),
-                            winslash = "/", mustWork = FALSE)
+my_tempdir <- fs::path_abs(path = fs::path(tempdir(), "testcreatedir"))
 dir.create(my_tempdir)
 tempdir_basename <- basename(tempdir())
 my_tempfile <- fs::path(my_tempdir, "test_df.csv")
 # Write csv-file, modified from example in help(write.table)
 write.table(x = data.frame(a = "a", b = pi), file = my_tempfile)
 
-pattern_temp <- file.path(tempdir_basename, "testcreatedir", "temp")
-pattern_subtemp <- file.path(pattern_temp, "subtemp")
+pattern_temp <- fs::path(tempdir_basename, "testcreatedir", "temp")
+pattern_subtemp <- fs::path(pattern_temp, "subtemp")
 
 
 # without date directory
 dir <- fs::path(my_tempdir, "temp_subdirF_dateF")
 expected_path <- dir
 
-expect_false(dir.exists(expected_path))
+expect_false(fs::dir_exists(expected_path))
 dir_no_date <- create_dir(dir = dir, add_date = FALSE)
-expect_true(dir.exists(expected_path))
+expect_true(fs::dir_exists(expected_path))
 expect_true(endsWith(
   dir_no_date,
   suffix = fs::path(tempdir_basename, "testcreatedir", "temp_subdirF_dateF")
@@ -74,9 +72,9 @@ expect_true(endsWith(
 dir <- fs::path(my_tempdir, "temp_subdirF_dateT")
 expected_path <- fs::path(dir, format(Sys.time(), format = "%Y_%m_%d"))
 
-expect_false(dir.exists(expected_path))
+expect_false(fs::dir_exists(expected_path))
 dir_date <- create_dir(dir = dir, add_date = TRUE)
-expect_true(dir.exists(expected_path))
+expect_true(fs::dir_exists(expected_path))
 expect_true(endsWith(
   dir_date,
   suffix = fs::path(tempdir_basename, "testcreatedir", "temp_subdirF_dateT",
@@ -87,9 +85,9 @@ expect_true(endsWith(
 dir <- fs::path(my_tempdir, "temp_subdirT_dateT")
 expected_path <- fs::path(dir, "subdir", format(Sys.time(), format = "%Y_%m_%d"))
 
-expect_false(dir.exists(expected_path))
+expect_false(fs::dir_exists(expected_path))
 dir_subdir_date <- create_dir(dir = fs::path(dir, "subdir"), add_date = TRUE)
-expect_true(dir.exists(expected_path))
+expect_true(fs::dir_exists(expected_path))
 expect_true(endsWith(
   dir_subdir_date,
   suffix = fs::path(tempdir_basename, "testcreatedir", "temp_subdirT_dateT", "subdir",
@@ -165,13 +163,11 @@ for(dir in list(fs::path(my_tempdir, " "),
     fixed = TRUE, strict = TRUE)
 }
 
-# Working directory is returned if 'dir' points to a file instead of a directory
-expect_warning(
-  expect_true(endsWith(
-    create_dir(dir = my_tempfile, add_date = FALSE),
-    suffix = basename(getwd())
-  )),
-  pattern = "Attempt to create directory failed", strict = TRUE, fixed = TRUE)
+# Throw an error if 'dir' points to a file instead of a directory (versions up
+# to 0.4.0 returned the working directory but that is unsafe).
+expect_error(
+  create_dir(dir = my_tempfile, add_date = FALSE),
+  pattern = "Failed to make directory", fixed = TRUE)
 
 # Checks on input to 'add_date'
 for(add_date in list(1, NA)) {

--- a/inst/tinytest/test_create_file_path.R
+++ b/inst/tinytest/test_create_file_path.R
@@ -3,16 +3,14 @@ tinytest::report_side_effects()
 #### Tests ####
 ##### Preparations #####
 # Create temporary directory and temporary file to use in tests.
-my_tempdir <- normalizePath(path = fs::path(tempdir(), "testcreatepath"),
-                            winslash = "/", mustWork = FALSE)
+my_tempdir <- fs::path_abs(path = fs::path(tempdir(), "testcreatepath"))
 tempdir_pattern <- paste0(basename(tempdir()), ".+$")
 tempdir_basename <- basename(tempdir())
 current_date_Ymd <- format(Sys.time(), format = "%Y_%m_%d")
 current_date_dmY <- format(Sys.time(), format = "%d_%m_%Y")
 
 dir.create(path = my_tempdir, showWarnings = FALSE, recursive = TRUE)
-my_tempfile <- normalizePath(path = fs::path(my_tempdir, "test_df.csv"),
-                             winslash = "/", mustWork = FALSE)
+my_tempfile <- fs::path_abs(path = fs::path(my_tempdir, "test_df.csv"))
 # Write csv-file, modified from example in help(write.table)
 write.table(x = data.frame(a = "a", b = pi), file = my_tempfile)
 
@@ -131,12 +129,9 @@ expect_true(endsWith(
 
 # Non-alphanumeric characters are *not* replaced (they used to be replaced in
 # earlier versions.
-# On Ubuntu and MacOS led to warning ''Repeated '/' or '\\' in 'dir' will be
-# ignored: /tmp/RtmpaJfn0F/working_dir/RtmpLIBaPm/testcreatepath', so now try if
-# using normalizePath() on 'my_tempdir' solves that.
 expect_true(endsWith(
   create_file_path(filename = "abc.txt", format_stamp = "%d#.%m_%Ydef",
-                   dir = normalizePath(my_tempdir), add_date = TRUE),
+                   dir = my_tempdir, add_date = TRUE),
   suffix = fs::path(tempdir_basename, "testcreatepath", current_date_Ymd,
                      paste0(format(Sys.time(), format = "%d#.%m_%Y"), "def_abc.txt"))
 ))
@@ -181,12 +176,10 @@ expect_true(endsWith(
   fs::path(tempdir_basename, "testcreatepath", ".txt", "abc.txt")
 ))
 
-expect_warning(
-  expect_true(endsWith(
+expect_error(
     create_file_path(filename = "testfile123.csv", format_stamp = "",
                      dir = my_tempfile, add_date = FALSE),
-    suffix = fs::path(basename(getwd()), "testfile123.csv"))),
-  pattern = "already exists", fixed = TRUE
+  pattern = "Failed to make directory", fixed = TRUE
 )
 
 for(dir in list(3, "", character(0), NULL, c("temp_p1", "temp_p2"))) {

--- a/inst/tinytest/test_create_tempdir.R
+++ b/inst/tinytest/test_create_tempdir.R
@@ -2,12 +2,12 @@ tinytest::report_side_effects()
 
 
 #### Tests ####
-my_tempdir <- normalizePath(path = tempdir(), winslash = "/", mustWork = FALSE)
+my_tempdir <- fs::path_abs(path = tempdir())
 
 # Possible to create a temporary subdirectory
-expect_false(dir.exists(fs::path(my_tempdir, "createtempdir")))
+expect_false(fs::dir_exists(fs::path(my_tempdir, "createtempdir")))
 res_subdir <- create_tempdir(subdir = "createtempdir")
-expect_true(dir.exists(res_subdir))
+expect_true(fs::dir_exists(res_subdir))
 
 # Error if temporary subdirectory already exists
 expect_error(create_tempdir(subdir = "createtempdir"),
@@ -31,9 +31,9 @@ expect_warning(
   pattern = "already exists", fixed = TRUE, strict = TRUE)
 
 # Also recognise that a directory already exists if it has subdirectories
-expect_false(dir.exists(fs::path(my_tempdir, "subdir", "abc")))
+expect_false(fs::dir_exists(fs::path(my_tempdir, "subdir", "abc")))
 res_subdir_recursive <- create_tempdir(subdir = fs::path("subdir", "abc"))
-expect_true(dir.exists(res_subdir_recursive))
+expect_true(fs::dir_exists(res_subdir_recursive))
 
 # Checks on input to 'subdir'
 for(subdir in list(3, "", character(0), NULL, c("temp_p1", "temp_p2"))) {

--- a/inst/tinytest/test_get_file_path.R
+++ b/inst/tinytest/test_get_file_path.R
@@ -2,9 +2,9 @@ tinytest::report_side_effects()
 
 
 #### Test the examples ####
-my_tempfiles <- normalizePath(
-  tempfile(pattern = c("some_filename", "another_filename"), fileext = ".txt"),
-  winslash = "/", mustWork = FALSE)
+my_tempfiles <- fs::path_abs(
+  tempfile(pattern = c("some_filename", "another_filename"), fileext = ".txt")
+  )
 
 # Create the files
 expect_silent(
@@ -89,12 +89,11 @@ expect_silent(
 
 # 'dir' points to a file instead of a directory
 expect_error(get_file_path(dir = my_tempfile, pattern = "test_"),
-             pattern = "points to a file but should point to a directory")
+             pattern = "Directory does not exist")
 
 # 'dir' points to a non-existing directory
 expect_error(get_file_path(dir = fs::path(my_tempdir, "abc"), pattern = "test_"),
-             pattern = paste0(basename(path = fs::path(my_tempdir, "abc")),
-                              "' does not exist"))
+             pattern = "Directory does not exist")
 
 # 'pattern' points to an existing directory instead of to an existing file
 dir.create(path = fs::path(tempdir(), "test_dir"), recursive = TRUE)

--- a/man/create_dir.Rd
+++ b/man/create_dir.Rd
@@ -19,23 +19,20 @@ directory is created.}
 current date in the \link[=strftime]{format} \code{YYYY_mm_dd}?}
 }
 \value{
-A character string with the absolute \link[=normalizePath]{normalized} path to
-the requested directory, returned \link[=invisible]{invisibly}. The
-\link[=getwd]{working directory} is returned if an attempt to create a directory
-fails, with a warning. This happens if \code{dir} points to an existing file
-instead of an directory.
+A character string with the \link[fs:path_abs]{absolute normalized} path to
+the requested directory, returned \link[=invisible]{invisibly}. An error is thrown
+if the attempt to create a directory fails. This happens if \code{dir} points to
+an existing file instead of an directory.
 }
 \description{
 Create a directory if it does not yet exist.
 }
 \details{
-The absolute \link[=normalizePath]{normalised} path is returned such that the
+The \link[fs:path_abs]{absolute normalised} path is returned such that the
 returned path still works if the \link[=getwd]{working directory} changes. On
 case-insensitive file systems (e.g., Windows and macOS), normalization
 adjusts the case to match case-insensitive names of directories that are
-already present (see the \code{Examples}). \code{"/"} instead of \code{"\\\\"} is used as
-\link[=normalizePath]{winslash} during normalisation, such that the returned path
-can be used in Windows' file system.
+already present (see the \code{Examples}).
 }
 \section{Side effects}{
 
@@ -50,7 +47,7 @@ my_tempdir <- fs::path(tempdir(), "testcreatedir")
 # Create directory 'dir_one' inside this temporary directory
 res_dir_one <- create_dir(dir = fs::path(my_tempdir, "dir_one"),
                           add_date = FALSE)
-dir.exists(res_dir_one) # TRUE
+fs::dir_exists(res_dir_one) # TRUE
 
 # An attempt to create a directory that already exists does not change any
 # directory and the same directory is returned.
@@ -69,7 +66,7 @@ identical(res_dir_one, res_dir_one_v3)
 # Create directory 'dir_two' with a subdirectory containing the current date
 res_dir_two <- create_dir(dir = fs::path(my_tempdir, "dir_two"),
                           add_date = TRUE)
-dir.exists(res_dir_two) # TRUE
+fs::dir_exists(res_dir_two) # TRUE
 
 # Cleaning up
 unlink(dirname(res_dir_one), recursive = TRUE)
@@ -81,7 +78,7 @@ rm(my_tempdir, res_dir_one, res_dir_one_v2, res_dir_two, res_dir_one_v3)
 \code{\link[=create_file_path]{create_file_path()}} to create a file path and creating the indicated
 directory if it does not yet exist; \code{\link[=create_tempdir]{create_tempdir()}} for a safe way
 to create temporary directories; \code{\link[checkinput:is_path]{checkinput::is_path()}} and references there about file
-paths and directories; \code{\link[=dir.exists]{dir.exists()}} and \code{\link[=dir.create]{dir.create()}} used by this
+paths and directories; \code{\link[fs:dir_exists]{fs::dir_exists()}} and \code{\link[=dir.create]{dir.create()}} used by this
 function; \code{\link[=get_file_path]{get_file_path()}} to check if a file exists and is a unique match to
 a pattern.
 

--- a/man/create_file_path.Rd
+++ b/man/create_file_path.Rd
@@ -59,8 +59,7 @@ if it does not yet exist.
 
 \examples{
 # Use a temporary directory to not write in the user's directory
-my_tempdir <- fs::path_abs(path = fs::path(tempdir(), "subdir"),
-                            winslash = "/", mustWork = FALSE)
+my_tempdir <- fs::path_abs(path = fs::path(tempdir(), "subdir"))
 
 (create_file_path(filename = "abc.txt", format_stamp = "",
                   dir = my_tempdir, add_date = TRUE))

--- a/man/create_file_path.Rd
+++ b/man/create_file_path.Rd
@@ -43,10 +43,8 @@ Create a file path, creating the indicated directory if it does not yet exist.
 character until the end of the file name) and should \strong{not} contain slashes
 or backslashes: use \code{dir} to indicate subdirectories.
 
-The absolute \link[=normalizePath]{normalised} path is returned such that the
-returned path still works if the \link[=getwd]{working directory} changes. \code{"/"}
-instead of \code{"\\\\"} is used as argument \link[=normalizePath]{winslash} such that
-the returned path can be used in Windows' file system.
+The \link[fs:path_abs]{absolute normalised} path is returned such that the
+returned path still works if the \link[=getwd]{working directory} changes.
 
 A warning is issued if the \strong{file} indicated by the returned path already
 exists. To prevent this when creating files in quick succession, use \code{"\%OSn"}
@@ -61,7 +59,7 @@ if it does not yet exist.
 
 \examples{
 # Use a temporary directory to not write in the user's directory
-my_tempdir <- normalizePath(path = fs::path(tempdir(), "subdir"),
+my_tempdir <- fs::path_abs(path = fs::path(tempdir(), "subdir"),
                             winslash = "/", mustWork = FALSE)
 
 (create_file_path(filename = "abc.txt", format_stamp = "",
@@ -90,7 +88,7 @@ rm(my_tempdir)
 \code{\link[checkinput:is_path]{checkinput::is_path()}} to check if a path is valid,
 \code{\link[=get_file_path]{get_file_path()}} to check if a file exists and is a unique match to a pattern,
 \code{\link[fs:path]{fs::path()}} to construct file paths in a platform-independent way,
-\code{\link[=normalizePath]{normalizePath()}} to create absolute normalised paths,
+\code{\link[fs:path_abs]{fs::path_abs()}} to create absolute normalised paths,
 \code{\link[=create_dir]{create_dir()}} to create a directory if it does not yet exist
 
 Other functions to handle paths and directories:

--- a/man/create_tempdir.Rd
+++ b/man/create_tempdir.Rd
@@ -12,7 +12,7 @@ of a \strong{not-yet} existing temporary subdirectory to be created inside
 \code{\link[=tempdir]{tempdir()}}. \code{subdir} should be a \link[checkinput:is_path]{valid path}.}
 }
 \value{
-The \link[=normalizePath]{normalized} path to the created temporary directory,
+The \link[fs:path_abs]{absolute normalized} path to the created temporary directory,
 returned \link[=invisible]{invisibly}.
 }
 \description{

--- a/man/get_file_path.Rd
+++ b/man/get_file_path.Rd
@@ -18,7 +18,7 @@ used to select names of files that are present in \code{dir}.}
 name?}
 }
 \value{
-A character string with the \link[=normalizePath]{normalized} path to the file
+A character string with the \link[fs:path_abs]{absolute normalized} path to the file
 with a name matching \code{pattern} if there is exactly one such file in directory
 \code{dir}. Otherwise an error is thrown. Use \code{\link[=basename]{basename()}} on the result to obtain
 the filename itself.
@@ -36,10 +36,8 @@ message indicates if any case-insensitive match is present.
 In contrast to the default of \code{\link[=list.files]{list.files()}}, \code{get_file_path()} also finds
 'hidden' files, i.e., files with names that start with a dot.
 
-Paths will be \link[=normalizePath]{normalized} to ensure they still work if the
-\link[=getwd]{working directory} changes. \code{"/"} instead of \code{"\\\\"} is
-used as argument \link[=normalizePath]{winslash} such that the returned path can
-be used in Windows' file system.
+Paths will be \link[fs:path_abs]{normalized} to ensure they still work if the
+\link[=getwd]{working directory} changes.
 }
 \examples{
 # Create files in a temporary directory so we know what is present.
@@ -78,7 +76,7 @@ checking they are a unique match to a pattern;
 \code{\link[=file.info]{file.info()}} and \code{\link[=file.access]{file.access()}} to extract information about files or
 directories;
 \code{\link[fs:path]{fs::path()}} to construct file paths in a platform-independent way;
-\code{\link[=normalizePath]{normalizePath()}} to create absolute paths.
+\code{\link[fs:path_abs]{fs::path_abs()}} to create absolute paths.
 
 Other functions to handle paths and directories:
 \code{\link[=create_dir]{create_dir()}},


### PR DESCRIPTION
### Breaking changes
- `create_dir()`: throw an error instead of returning the working directory if creating the directory fails: returning the working directory is an unsafe fall-back because the reasonable assumption that the newly-created directory did not yet exist before `create_dir()` was called then could lead to deleting the working directory.
- `create_file_path()` and `get_file_path()`: no need to warn about an already-existing directory with a path equal to a file path or about an already-existing file with a path equal to a directory path.

### Programming
- Replace `normalizePath()` by `fs::path_abs()`.
- Replace `dir.exists()` by `fs::dir_exists()`.