### PR TITLE
Incorporate bugfixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 Imports: 
-    checkinput (>= 0.9.0),
+    checkinput (>= 0.10.0),
     fs,
     utils
 Remotes: github::JesseAlderliesten/checkinput

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,13 @@
 # progutils 0.5.1
 
+### Breaking changes
+- Dependency `checkinput`: increase minimum version from `0.9.0` to `0.10.0` to
+  incorporate bugfix: `is_path("C:")` would warn that `filename` should not
+  contain `:`.
+
 ### Bugfixes
+- `dir_create()` uses argument `recurse` instead of `recursive`, which is `TRUE`
+  by default.
 - `get_file_path()` would return directories matching `pattern`.
 
 

--- a/R/create_dir.R
+++ b/R/create_dir.R
@@ -90,10 +90,10 @@ create_dir <- function(dir = fs::path(".", "output"), add_date = TRUE) {
   # fs::dir_exists() returns FALSE if 'dir' is a file instead of a directory but
   # fs::dir_create() then throws an informative error.
   if(!fs::dir_exists(dir)) {
-    # Using 'recurse = TRUE' to allow creation of subdirectories inside a
+    # By default 'recurse' is TRUE to allow creation of subdirectories inside a
     # not-yet existing directory (e.g., creating './output/<date>' if './output'
     # does not yet exist).
-    fs::dir_create(path = dir, recurse = TRUE)
+    fs::dir_create(path = dir)
   }
 
   invisible(dir)

--- a/R/create_tempdir.R
+++ b/R/create_tempdir.R
@@ -22,7 +22,7 @@
 #'
 #' @section Side effects:
 #' The temporary directory indicated by the returned path is
-#' [created][dir.create()] if does not yet exist.
+#' [created][dir.create()].
 #'
 #' @section Usage in practice:
 #' Examples and tests should **not** write to the [working directory][getwd()]

--- a/inst/tinytest/test_create_file_path.R
+++ b/inst/tinytest/test_create_file_path.R
@@ -9,7 +9,7 @@ tempdir_basename <- basename(tempdir())
 current_date_Ymd <- format(Sys.time(), format = "%Y_%m_%d")
 current_date_dmY <- format(Sys.time(), format = "%d_%m_%Y")
 
-fs::dir_create(path = my_tempdir, showWarnings = FALSE, recursive = TRUE)
+fs::dir_create(path = my_tempdir, showWarnings = FALSE)
 my_tempfile <- fs::path_abs(path = fs::path(my_tempdir, "test_df.csv"))
 # Write csv-file, modified from example in help(write.table)
 write.table(x = data.frame(a = "a", b = pi), file = my_tempfile)

--- a/inst/tinytest/test_get_file_path.R
+++ b/inst/tinytest/test_get_file_path.R
@@ -96,8 +96,7 @@ expect_error(get_file_path(dir = fs::path(my_tempdir, "abc"), pattern = "test_")
              pattern = "Directory does not exist")
 
 # 'pattern' points to an existing directory instead of to an existing file
-fs::dir_create(path = fs::path(tempdir(), "testgetfilepath", "test_dir", "abc"),
-               recursive = TRUE)
+fs::dir_create(path = fs::path(tempdir(), "testgetfilepath", "test_dir", "abc"))
 expect_error(get_file_path(dir = fs::path(tempdir(), "testgetfilepath", "test_dir"),
                            pattern = "abc"),
              pattern = "No matches to pattern 'abc' are present",

--- a/man/create_tempdir.Rd
+++ b/man/create_tempdir.Rd
@@ -31,7 +31,7 @@ yet exist.
 \section{Side effects}{
 
 The temporary directory indicated by the returned path is
-\link[=dir.create]{created} if does not yet exist.
+\link[=dir.create]{created}.
 }
 
 \section{Usage in practice}{


### PR DESCRIPTION
### Breaking changes
- Dependency `checkinput`: increase minimum version from `0.9.0` to `0.10.0` to incorporate bugfix: `is_path("C:")` would warn that `filename` should not contain `:`.

### Bugfixes
- `dir_create()` uses argument `recurse` instead of `recursive`, which is `TRUE` by default.