### PR TITLE
progutils 0.7.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 Imports: 
-    checkinput (>= 0.11.0),
+    checkinput (>= 0.12.0),
     fs,
     utils
 Remotes: github::JesseAlderliesten/checkinput

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: progutils
 Title: Programming Utilities
-Version: 0.6.0
+Version: 0.7.0
 Authors@R: 
     person("Jesse", "Alderliesten", email = "jessealderliesten@hotmail.com",
     role = c("aut", "cre"), comment = c(ORCID = "0000-0003-1132-4310"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,16 @@
+# progutils 0.7.0
+
+### Breaking changes
+- Dependency `checkinput`: increase minimum version from `0.11.0` to `0.12.0` to
+  use argument `require_sep` from `is_path()` in `create_file_path()` and in
+  `create_tempdir()`.
+
+
 # progutils 0.6.0
 
 ### Breaking changes
 - Dependency `checkinput`: increase minimum version from `0.10.0` to `0.11.0` to
-  incorporate change of argument name `allow_zero_length()` to
-  `allow_zerolength()`.
+  incorporate change of argument name `allow_zero_length` to `allow_zerolength`.
 
 
 # progutils 0.5.1

--- a/R/create_file_path.R
+++ b/R/create_file_path.R
@@ -72,7 +72,8 @@ create_file_path <- function(filename, format_stamp = "%Y_%m_%d_%H_%M_%S",
                              dir = fs::path_wd("output"), add_date = TRUE) {
   filename_label <- deparse1(substitute(filename))
 
-  stopifnot(checkinput::is_character(filename), checkinput::is_path(filename),
+  stopifnot(checkinput::is_character(filename),
+            checkinput::is_path(filename, require_sep = FALSE),
             checkinput::is_character(format_stamp, allow_empty = TRUE),
             checkinput::is_character(dir), checkinput::is_path(dir),
             checkinput::is_logical(add_date))

--- a/R/create_tempdir.R
+++ b/R/create_tempdir.R
@@ -61,7 +61,8 @@
 #'
 #' @export
 create_tempdir <- function(subdir = "subdir") {
-  stopifnot(checkinput::is_character(subdir), checkinput::is_path(subdir))
+  stopifnot(checkinput::is_character(subdir),
+            checkinput::is_path(subdir, require_sep = FALSE))
   subdir_target <- fs::path_abs(path = fs::path(tempdir(), subdir))
   tempdir_normalised <- fs::path_abs(tempdir())
   if(!grepl(pattern = basename(tempdir()), x = subdir_target, fixed = TRUE)) {

--- a/inst/tinytest/test_create_dir.R
+++ b/inst/tinytest/test_create_dir.R
@@ -23,9 +23,6 @@ expect_true(endsWith(
 # On case-insensitive file systems such as Windows and macOS, the directory
 # created below is the same as 'res_dir_one'. On case-sensitive file systems
 # such as Ubuntu, it differs in case from 'res_dir_one'.
-# Notes:
-# - Issues a spurious warning on MacOS ('Repeated '/' or '\\' in 'dir'') because
-#   there the part before the output of 'tempdir()' contains repeated slashes.
 create_dir(dir = fs::path(my_tempdir, "dir_ONE"), add_date = FALSE)
 
 res_dir_two <- create_dir(dir = fs::path(my_tempdir, "dir_two"),

--- a/inst/tinytest/test_create_file_path.R
+++ b/inst/tinytest/test_create_file_path.R
@@ -88,7 +88,7 @@ for(filenm_in in c("abcd", ".", ".txt", ".html")) {
 expect_warning(
   expect_error(
     create_file_path(filename = "abc.", dir = my_tempdir, format_stamp = ""),
-    pattern = "is_path(filename) is not TRUE", fixed = TRUE),
+    pattern = "is_path(filename, require_sep = FALSE) is not TRUE", fixed = TRUE),
   pattern = "Components of 'filename' should not end with ' ' or '.'",
   strict = TRUE, fixed = TRUE)
 
@@ -105,7 +105,7 @@ expect_warning(
   expect_error(
     create_file_path(filename = "ff .txt", format_stamp = "",
                      dir = my_tempdir, add_date = FALSE),
-    pattern = "is_path(filename) is not TRUE", fixed = TRUE),
+    pattern = "is_path(filename, require_sep = FALSE) is not TRUE", fixed = TRUE),
   pattern = "'filename' should not end with ' ' or '.'", strict = TRUE, fixed = TRUE)
 
 # No warning message specified: on Windows with R 4.6.0 the warning message is

--- a/inst/tinytest/test_create_tempdir.R
+++ b/inst/tinytest/test_create_tempdir.R
@@ -79,7 +79,7 @@ for(subdir in list("temp_p7.", "temp_p8 ")) {
   expect_warning(
     expect_error(
       create_tempdir(subdir = subdir),
-      pattern = "is_path(subdir) is not TRUE", fixed = TRUE),
+      pattern = "is_path(subdir, require_sep = FALSE) is not TRUE", fixed = TRUE),
     pattern = "should not end with ' ' or '.'", strict = TRUE, fixed = TRUE)
 }
 


### PR DESCRIPTION
### Breaking changes
- Dependency `checkinput`: increase minimum version from `0.11.0` to `0.12.0` to use argument `require_sep` from `is_path()` in `create_file_path()` and in `create_tempdir()`.