### PR TITLE
progutils 0.8.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: progutils
 Title: Programming Utilities
-Version: 0.7.0
+Version: 0.8.0
 Authors@R: 
     person("Jesse", "Alderliesten", email = "jessealderliesten@hotmail.com",
     role = c("aut", "cre"), comment = c(ORCID = "0000-0003-1132-4310"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 Imports: 
-    checkinput (>= 0.12.0),
+    checkinput (>= 1.0.0),
     fs,
     utils
 Remotes: github::JesseAlderliesten/checkinput

--- a/NEWS.md
+++ b/NEWS.md
@@ -93,14 +93,6 @@
   characters other than dots and underscores by underscores instead of replacing
   non-alphanumeric characters other than underscores by dots.
 
-### Documentation
-- `as.numeric_safe()`: moved `Note` to `Details`. Condensed example section.
-- `create_tempdir()`: add section `Usage in practice` which explains why using
-  `create_tempdir()` is preferable over using `tempdir()`.
-- `head_tail()`: no longer erroneously document that `n` can be zero. Removed
-  uninformative example.
-- `is_path()`: add section `Programming notes` about file separators.
-
 
 # progutils 0.0.11
 
@@ -212,12 +204,3 @@
   recognise the extension of file names that end in a dot.
 - `reorder_cols()`: reorder columns.
 - `reorder_levels()`: reorder factor levels.
-
-### Documentation
-- `create_dir()`: move some documentation to `create_path()`; document format of
-  date-time stamp with same case as `strftime()`.
-
-
-# progutils 0.0.2
-
-NEWS for this and earlier versions has not been tracked.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# progutils 0.8.0
+
+### Breaking changes
+- Dependency `checkinput`: increase minimum version from `0.12.0` to `1.0.0` to
+  depend on a stable version.
+
+
 # progutils 0.7.0
 
 ### Breaking changes

--- a/README.Rmd
+++ b/README.Rmd
@@ -89,4 +89,4 @@ cat(wrap_text(paste(msg_part_one, vect_to_char(num_vect)), width = 20,
 Many packages with miscellaneous functions exist on [GitHub](https://github.com/)
 and [CRAN](https://cran.r-project.org/web/packages/available_packages_by_name.html):
 frequently they have 'misc' or 'util' in their title or description. In addition,
-many packages have an `utils` folder in `R`.
+many packages have an `utils` folder in their `R` directory.

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ check equality, construct messages, or handle files and directories.
 
 ## Installation
 
-You can visit the [progutils
+Visit the [progutils
 website](https://jessealderliesten.github.io/progutils/) to explore the
-package. To use `progutils`, you have to install it from
+package, or install `progutils` from
 [GitHub](https://github.com/JesseAlderliesten/progutils) using the
 following R code (you need to run R as administrator):
 
@@ -102,4 +102,4 @@ Many packages with miscellaneous functions exist on
 [GitHub](https://github.com/) and
 [CRAN](https://cran.r-project.org/web/packages/available_packages_by_name.html):
 frequently they have ‘misc’ or ‘util’ in their title or description. In
-addition, many packages have an `utils` folder in `R`.
+addition, many packages have an `utils` folder in their `R` directory.


### PR DESCRIPTION
### Breaking changes
- Dependency `checkinput`: increase minimum version from `0.12.0` to `1.0.0` to depend on a stable version.