### PR TITLE
progutils 0.9.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: progutils
 Title: Programming Utilities
-Version: 0.8.0
+Version: 0.9.0
 Authors@R: 
     person("Jesse", "Alderliesten", , "jessealderliesten@hotmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-1132-4310"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,21 +2,23 @@ Package: progutils
 Title: Programming Utilities
 Version: 0.8.0
 Authors@R: 
-    person("Jesse", "Alderliesten", email = "jessealderliesten@hotmail.com",
-    role = c("aut", "cre"), comment = c(ORCID = "0000-0003-1132-4310"))
+    person("Jesse", "Alderliesten", , "jessealderliesten@hotmail.com", role = c("aut", "cre"),
+           comment = c(ORCID = "0000-0003-1132-4310"))
 Description: Programming Utilities of Jesse Alderliesten.
 License: MIT + file LICENSE
-Encoding: UTF-8
-Roxygen: list(markdown = TRUE)
+URL: https://github.com/JesseAlderliesten/progutils,
+    https://jessealderliesten.github.io/progutils/
+BugReports: https://github.com/JesseAlderliesten/progutils/issues
 Imports: 
     checkinput (>= 1.0.0),
     fs,
     utils
-Remotes: github::JesseAlderliesten/checkinput
 Suggests:
     stats,
     tinytest (>= 1.4.1),
     tools
-URL: https://github.com/JesseAlderliesten/progutils, https://jessealderliesten.github.io/progutils/
-BugReports: https://github.com/JesseAlderliesten/progutils/issues
+Remotes: 
+    github::JesseAlderliesten/checkinput
 Config/roxygen2/version: 8.0.0
+Encoding: UTF-8
+Roxygen: list(markdown = TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# progutils 0.9.0
+
+### Breaking changes
+- Update `create_tempdir()`: always create a new temporary directory instead of
+  throwing an error if `subdir` is re-used. Not allow creating recursive
+  subdirectories: cleaning up such directories is unsafe. Rename argument
+  `subdir` to `pattern`.
+
+
 # progutils 0.8.0
 
 ### Breaking changes

--- a/R/create_tempdir.R
+++ b/R/create_tempdir.R
@@ -1,20 +1,30 @@
-#' Create a temporary directory
+#' Create a new temporary directory
 #'
-#' Create a temporary directory that can safely be removed.
+#' Create a new temporary directory that can safely be removed.
 #'
-#' @param subdir A [character string][checkinput::is_character()] with the name
-#' of a **not-yet** existing temporary subdirectory to be created inside
-#' [tempdir()]. `subdir` should be a [valid path][checkinput::is_path()].
+#' @param pattern A [character string][checkinput::is_character()] with the
+#' initial part of the name of the new temporary directory, only containing
+#' characters that are valid in a [path][checkinput::is_path()].
 #'
 #' @details
-#' `subdir` is created inside [tempdir()] and an error is thrown if it already
-#' exists or creating the directory fails. This ensures that [removing][unlink()]
-#' the created directory does not remove files that are still needed by other
-#' processes (see `Usage in practice` below).
+#' The new directory is [created][dir.create()] inside [tempdir()]. Its
+#' [name][tempfile()] starts with the string given by `pattern` and is followed
+#' by a random string in hex. This random string **might** contain a dot (`.`)
+#' such that the directory might appear to have a file extension, see the
+#' section `Source` in `help("tempdir")`. An error is thrown if creating the
+#' directory fails.
 #'
-#' It is possible to create subdirectories inside a not-yet existing directory
-#' (e.g., to create `<tempdir>/output/outputsub` if `<tempdir>/output` does not
-#' yet exist.
+#' It is **not** possible to create recursive subdirectories (e.g.,
+#' `tempdir/subtempdir/otherdir`, see the `Examples`) because
+#' [removing][unlink()] such directories might remove files that are still
+#' needed by other processes.
+#'
+#' Although the temporary directory given by [tempdir()] will normally be
+#' automatically [removed][unlink()] when \R [quits][quit()] (and operating
+#' systems might
+#' [periodically](https://cran.r-project.org/doc/manuals/R-admin.html#Running-R)
+#' empty the temporary directory), the created subdirectories should be removed
+#' once they are not needed anymore, see the section `Usage in practice` below.
 #'
 #' @returns
 #' The [absolute normalized][fs::path_abs()] path to the created temporary
@@ -22,82 +32,95 @@
 #'
 #' @section Side effects:
 #' The temporary directory indicated by the returned path is
-#' [created][dir.create()].
+#' [created][fs::dir_create()] inside [tempdir()].
 #'
 #' @section Usage in practice:
-#' Examples and tests should **not** write to the [working directory][getwd()]
-#' but to a temporary directory that is cleaned up afterwards. Although
-#' [tempdir()] points to a temporary directory, that directory should **not** be
-#' removed because [RStudio](https://posit.co/products/open-source/rstudio) also
-#' uses it. Instead, store the paths to temporary files written to [tempdir()]
-#' and [unlink][unlink()] those paths when cleaning up, or create a temporary
-#' subdirectory in `tempdir()` which can be completely be removed when cleaning
-#' up. `use_tempdir()` follows the latter approach. It is good practice to
-#' create the complete temporary directory with all required files and folders
-#' before running any example or test: this ensures no spurious matches occur if
-#' examples or tests are removed or added.
+#' `Examples` and `tests` should write to a temporary directory that is cleaned
+#' up afterwards (otherwise R cmd check will issue a `Note` about
+#' '[detritus in the temp directory](
+#' https://contributor.r-project.org/cran-cookbook/code_issues.html#leaving-files-in-the-temporary-directory)'
+#' and
+#' [CRAN](https://cran.r-project.org/web/packages/policies.html#Source-packages)
+#' will not accept your package). Although [tempdir()] points to a temporary
+#' directory, that directory should **not** be removed because other \R
+#' processes and [RStudio](https://posit.co/products/open-source/rstudio) might
+#' use it. Instead, create a temporary subdirectory in [tempdir()] and
+#' afterwards clean up by [removing][unlink()] that subdirectory:
+#'
+#' ```
+#' my_tempdir <- create_tempdir(pattern = "subtempdir")
+#' < do stuff >
+#' unlink(my_tempdir, recursive = TRUE)
+#' ```
+#'
+#' It is good practice to create the complete temporary directory with all
+#' required files and folders before running any test for the presence or
+#' absence of particular files or folders: this ensures no spurious matches
+#' occur if examples or tests are removed or added.
+#'
+#' @inheritSection checkinput::is_path Programming notes
 #'
 #' @seealso
+#' [tempfile()] used in this function to create the paths for the temporary
+#' directory;
+#' [local()] and
+#' [withr::local_tempdir()](https://withr.r-lib.org/reference/with_tempfile.html)
+#' for automated deletion of temporary directories;
 #' [create_dir()] to create (non-temporary) directories;
-#' [checkinput::is_path()] to check if a path is valid, and the 'Note on paths'
+#' [checkinput::is_path()] to check if a path is valid, with the `Note on paths`
 #' in its documentation.
 #'
 #' @family functions to handle paths and directories
 #'
 #' @examples
-#' tempdir()
+#' tempdir(check = TRUE)
 #' # Create a directory inside the directory returned by 'tempdir()'
-#' (tempdir_std <- create_tempdir(subdir = "examplesubtempdir"))
+#' (my_subtempdir_ex1 <- create_tempdir(pattern = "subtempdir"))
 #'
-#' # Error if the directory already exists
-#' try(create_tempdir(subdir = "examplesubtempdir"))
+#' # Using the same 'pattern' again creates another directory
+#' (my_subtempdir_ex2 <- create_tempdir(pattern = "subtempdir"))
 #'
-#' # It is possible to create recursive directories
-#' (tempdir_recursive <- create_tempdir(subdir = fs::path("abc", "def")))
+#' # It is not possible to create recursive subdirectories
+#' try(no_subtempdir <- create_tempdir(pattern = "subtempdir/otherdir"))
+#' try(no_subtempdir <- create_tempdir(pattern = "subtempdir\\otherdir"))
 #'
 #' # Clean up
-#' unlink(c(tempdir_std, dirname(tempdir_recursive)), recursive = TRUE)
-#' rm(tempdir_recursive, tempdir_std)
+#' unlink(c(my_subtempdir_ex1, my_subtempdir_ex2), recursive = TRUE)
+#' rm(my_subtempdir_ex1, my_subtempdir_ex2)
 #'
 #' @export
-create_tempdir <- function(subdir = "subdir") {
-  stopifnot(checkinput::is_character(subdir),
-            checkinput::is_path(subdir, require_sep = FALSE))
-  subdir_target <- fs::path_abs(path = fs::path(tempdir(), subdir))
-  tempdir_normalised <- fs::path_abs(tempdir())
-  if(!grepl(pattern = basename(tempdir()), x = subdir_target, fixed = TRUE)) {
-    stop("Using ", paste_quoted(subdir),
-         " as 'subdir' would write above 'tempdir()' which is not safe: ",
-         subdir_target)
+create_tempdir <- function(pattern = "tempdir") {
+  stopifnot(
+    "'pattern' should be a non-empty, non-NA_character_ character string" =
+      checkinput::is_character(pattern),
+    "'pattern' should not include file separators" = pattern == basename(pattern))
+
+  # Inspired by withr::local_tempdir()
+  tempdir_target <- tempfile(pattern = pattern, tmpdir = tempdir(check = TRUE))
+  stopifnot(checkinput::is_path(tempdir_target))
+  tempdir_target <- as.character(fs::path_abs(path = tempdir_target))
+
+  # fs::file_exists(tempdir_target) returns TRUE if 'tempdir_target' is an
+  # existing file or an existing directory.
+  if(fs::file_exists(tempdir_target)) {
+    # This error should not occur if 'tempfile()' worked correctly when creating
+    # 'tempdir_target' but makes it possible to detect problems that might arise.
+    stop("Temporary directory already exists (possibly as a file): change",
+         " 'pattern' (", paste_quoted(pattern), "):\n", tempdir_target)
   }
 
-  if(basename(subdir_target) == basename(tempdir())) {
-    stop("Using ", paste_quoted(subdir),
-         " as 'subdir' would write to 'tempdir()' which is not safe: ",
-         tempdir_normalised)
+  # Notes:
+  # - It was checked above that the target directory does not yet exist as a
+  #   directory nor as a file, so it is not a problem that fs::dir_exists() does
+  #   not complain if a directory already exists.
+  # - Using 'recurse = FALSE' to not allow the creation of recursive
+  #   subdirectories.
+  tempdir_target <- as.character(
+    fs::path_abs(fs::dir_create(path = tempdir_target, recurse = FALSE)))
+  if(!fs::dir_exists(tempdir_target)) {
+    stop("Attempt to create a subdirectory in the temporary directory failed:\n",
+         tempdir_target)
   }
 
-  # fs::dir_exists() returns FALSE if 'subdir_target' is a file instead of a
-  # directory.
-  if(!fs::dir_exists(subdir_target)) {
-    # Notes:
-    # - This branch is only used if the directory did not yet exist as directory,
-    #   so it is not a problem that dir.create() returns FALSE if a directory
-    #   already exists. However, the path can already exist as a file: then the
-    #   attempt to create it as a directory will fail, resulting in an error.
-    # - Not using fs::dir_create() because that returns the path instead of a
-    #   boolean vector indicating if creation succeeded.
-    # - Using 'recursive = TRUE' to allow creation of subdirectories inside a
-    #   not-yet existing directory (e.g., creating '<tempdir>/output/<date>' if
-    #   '<tempdir>/output' does not yet exist).
-    if(!dir.create(path = subdir_target, recursive = TRUE,
-                   showWarnings = TRUE)) {
-      stop("Attempt to create a subdirectory in the temporary directory failed:\n",
-           subdir_target)
-    }
-  } else {
-    stop("Temporary directory already exists: change 'subdir' (",
-         paste_quoted(subdir), "):\n", subdir_target)
-  }
-  invisible(subdir_target)
+  invisible(tempdir_target)
 }

--- a/R/create_tempdir.R
+++ b/R/create_tempdir.R
@@ -93,7 +93,10 @@ create_tempdir <- function(pattern = "tempdir") {
   stopifnot(
     "'pattern' should be a non-empty, non-NA_character_ character string" =
       checkinput::is_character(pattern),
-    "'pattern' should not include file separators" = pattern == basename(pattern))
+    # Using 'pattern == basename(pattern)' to detect slashes does not work on
+    # Ubuntu and MacOS
+    "'pattern' should not include file separators" =
+      !grepl(pattern = "\\\\", x = pattern) && !grepl(pattern = "/", x = pattern))
 
   # Inspired by withr::local_tempdir()
   tempdir_target <- tempfile(pattern = pattern, tmpdir = tempdir(check = TRUE))

--- a/inst/tinytest/test_create_tempdir.R
+++ b/inst/tinytest/test_create_tempdir.R
@@ -1,96 +1,97 @@
 tinytest::report_side_effects()
 
+#### Test the examples ####
+basename_my_tempdir <- basename(tempdir(check = TRUE))
+pattern <- "subtempdir"
 
-#### Tests ####
-my_tempdir <- fs::path_abs(path = tempdir())
+# Create a directory inside the directory returned by 'tempdir()'
+my_subtempdir_ex1 <- create_tempdir(pattern = pattern)
 
-# Possible to create a temporary subdirectory
-expect_false(fs::dir_exists(fs::path(my_tempdir, "createtempdir")))
-res_subdir <- create_tempdir(subdir = "createtempdir")
-expect_true(fs::dir_exists(res_subdir))
+# Using the same 'pattern' again creates another directory
+my_subtempdir_ex2 <- create_tempdir(pattern = pattern)
 
-# Error if temporary subdirectory already exists
-expect_error(create_tempdir(subdir = "createtempdir"),
-             pattern = paste0("Temporary directory already exists: change",
-                              " 'subdir' ('createtempdir')"), fixed = TRUE)
+# Test that directories exist
+expect_true(fs::dir_exists(my_subtempdir_ex1))
+expect_true(fs::dir_exists(my_subtempdir_ex2))
 
-# Temporary subdirectory is writeable
-my_tempfile <- fs::path(res_subdir, "test_df.csv")
-expect_false(file.exists(my_tempfile))
-# Write csv-file, modified from example in help(write.table)
-write.table(x = data.frame(a = "a", b = pi), file = my_tempfile)
-expect_true(file.exists(my_tempfile))
+# Test that directories are inside 'tempdir()'
+expect_true(basename(dirname(my_subtempdir_ex1)) == basename_my_tempdir)
+expect_true(basename(dirname(my_subtempdir_ex2)) == basename_my_tempdir)
 
-# Target points to a file instead of a directory
-expect_warning(
-  expect_error(
-    create_tempdir(subdir = fs::path(basename(dirname(my_tempfile)),
-                                     basename(my_tempfile))),
-    pattern = "create a subdirectory in the temporary directory failed",
-    fixed = TRUE),
-  pattern = "already exists", fixed = TRUE, strict = TRUE)
+# Test that names start with 'pattern'
+expect_true(startsWith(x = basename(my_subtempdir_ex1), prefix = pattern))
+expect_true(startsWith(x = basename(my_subtempdir_ex2), prefix = pattern))
 
-# Also recognise that a directory already exists if it has subdirectories
-expect_false(fs::dir_exists(fs::path(my_tempdir, "subdir", "abc")))
-res_subdir_recursive <- create_tempdir(subdir = fs::path("subdir", "abc"))
-expect_true(fs::dir_exists(res_subdir_recursive))
+# Test that names are not equal to 'pattern'
+expect_true(basename(my_subtempdir_ex1) != pattern)
+expect_true(basename(my_subtempdir_ex2) != pattern)
 
-# Checks on input to 'subdir'
-for(subdir in list(3, "", character(0), NULL, c("temp_p1", "temp_p2"))) {
-  expect_error(
-    create_tempdir(subdir = subdir),
-    pattern = "is_character(subdir) is not TRUE", fixed = TRUE)
-}
+# Test that names are not the same
+expect_true(my_subtempdir_ex1 != my_subtempdir_ex2)
 
-# Trailing '\\' is changed to '/' but trailing '/' is removed
-subdir_in <- c("tem\\p_p1", "temp_p2\\", "tem/p_p3", "temp_p4/")
-subdir_out <- c("tem/p_p1", "temp_p2", "tem/p_p3", "temp_p4")
-for(ind_subdir in seq_along(subdir_in)) {
-  expect_true(endsWith(
-    create_tempdir(subdir = subdir_in[ind_subdir]),
-    # Need paste0() because fs::path() removes trailing slashes
-    paste0(basename(my_tempdir), "/", subdir_out[ind_subdir])
-  ))
-}
-
-expect_silent(
-  expect_true(endsWith(
-    create_tempdir(subdir = "\\temp_p5"),
-    suffix = fs::path(basename(my_tempdir), "temp_p5")
-  ))
-)
-
-expect_silent(
-  expect_true(endsWith(
-    create_tempdir(subdir = "/temp_p6"),
-    suffix = fs::path(basename(my_tempdir), "temp_p6")
-  ))
-)
+# Test that it is not possible to create recursive directories
+expect_error(
+  create_tempdir(pattern = "subtempdir/otherdir"),
+  pattern = "'pattern' should not include file separators", fixed = TRUE)
 
 expect_error(
-  create_tempdir(subdir = "."),
-  pattern = "would write to 'tempdir()'", fixed = TRUE)
-
-expect_error(
-  create_tempdir(subdir = ".."),
-  pattern = "would write above 'tempdir()'", fixed = TRUE)
-
-for(subdir in list("temp_p7.", "temp_p8 ")) {
-  expect_warning(
-    expect_error(
-      create_tempdir(subdir = subdir),
-      pattern = "is_path(subdir, require_sep = FALSE) is not TRUE", fixed = TRUE),
-    pattern = "should not end with ' ' or '.'", strict = TRUE, fixed = TRUE)
-}
-
+  create_tempdir(pattern = "subtempdir\\otherdir"),
+  pattern = "'pattern' should not include file separators", fixed = TRUE)
 
 #### Delete the created temporary files ####
-unlink(c(res_subdir, dirname(res_subdir_recursive),
-         fs::path(my_tempdir, subdir_out), fs::path(my_tempdir, "temp_p5"),
-         fs::path(my_tempdir, "temp_p6"), fs::path(my_tempdir, "tem")),
-       recursive = TRUE)
+unlink(c(my_subtempdir_ex1, my_subtempdir_ex2), recursive = TRUE)
+expect_false(fs::dir_exists(my_subtempdir_ex1))
+expect_false(fs::dir_exists(my_subtempdir_ex2))
+
+#### Remove objects used in tests ####
+rm(my_subtempdir_ex1, my_subtempdir_ex2, basename_my_tempdir, pattern)
+
+
+#### Tests ####
+pattern <- "subtempdir"
+my_subtempdir_t1 <- create_tempdir()
+my_tempfile <- fs::path(my_subtempdir_t1, "test_df.csv")
+my_subtempdir_t2 <- create_tempdir(pattern = ".")
+
+# Test that temporary subdirectory is writeable by writing a csv-file, modified
+# from an example in help(write.table)
+expect_false(fs::is_file(my_tempfile))
+write.table(x = data.frame(a = "a", b = pi), file = my_tempfile)
+expect_true(fs::is_file(my_tempfile))
+
+# Test that pattern '"."' is accepted
+expect_true(fs::dir_exists(my_subtempdir_t2))
+
+#### Delete the created temporary files ####
+unlink(c(my_subtempdir_t1, my_subtempdir_t2), recursive = TRUE)
+
+#### Remove objects used in tests ####
+rm(my_tempfile, pattern, my_subtempdir_t1, my_subtempdir_t2)
+
+
+#### Invalid input ####
+for(pattern in list(3, NULL, character(0), "", c("temp_p1", "temp_p2"))) {
+    expect_error(
+      create_tempdir(pattern = pattern),
+      pattern = "'pattern' should be a non-empty, non-NA_character_ character string",
+      fixed = TRUE)
+}
+
+for(pattern in c("tem\\p_p1", "temp_p2\\", "tem/p_p3", "temp_p4/", "\\temp_p5",
+                 "/temp_p6")) {
+  expect_error(
+    create_tempdir(pattern = pattern),
+    pattern = "'pattern' should not include file separators", fixed = TRUE)
+}
+
+expect_warning(
+  expect_error(
+    create_tempdir(pattern = "abc|def"),
+    pattern = "checkinput::is_path(tempdir_target) is not TRUE",
+    fixed = TRUE),
+  pattern = "'tempdir_target' should not contain '\"', '*', '?', '|', '<' or '>'",
+  strict = TRUE, fixed = TRUE)
 
 
 #### Remove objects used in tests ####
-rm(ind_subdir, my_tempdir, my_tempfile, res_subdir, res_subdir_recursive,
-   subdir, subdir_in, subdir_out)
+rm(pattern)

--- a/man/create_tempdir.Rd
+++ b/man/create_tempdir.Rd
@@ -2,72 +2,108 @@
 % Please edit documentation in R/create_tempdir.R
 \name{create_tempdir}
 \alias{create_tempdir}
-\title{Create a temporary directory}
+\title{Create a new temporary directory}
 \usage{
-create_tempdir(subdir = "subdir")
+create_tempdir(pattern = "tempdir")
 }
 \arguments{
-\item{subdir}{A \link[checkinput:is_character]{character string} with the name
-of a \strong{not-yet} existing temporary subdirectory to be created inside
-\code{\link[=tempdir]{tempdir()}}. \code{subdir} should be a \link[checkinput:is_path]{valid path}.}
+\item{pattern}{A \link[checkinput:is_character]{character string} with the
+initial part of the name of the new temporary directory, only containing
+characters that are valid in a \link[checkinput:is_path]{path}.}
 }
 \value{
 The \link[fs:path_abs]{absolute normalized} path to the created temporary
 directory, returned \link[=invisible]{invisibly}.
 }
 \description{
-Create a temporary directory that can safely be removed.
+Create a new temporary directory that can safely be removed.
 }
 \details{
-\code{subdir} is created inside \code{\link[=tempdir]{tempdir()}} and an error is thrown if it already
-exists or creating the directory fails. This ensures that \link[=unlink]{removing}
-the created directory does not remove files that are still needed by other
-processes (see \verb{Usage in practice} below).
+The new directory is \link[=dir.create]{created} inside \code{\link[=tempdir]{tempdir()}}. Its
+\link[=tempfile]{name} starts with the string given by \code{pattern} and is followed
+by a random string in hex. This random string \strong{might} contain a dot (\code{.})
+such that the directory might appear to have a file extension, see the
+section \code{Source} in \code{help("tempdir")}. An error is thrown if creating the
+directory fails.
 
-It is possible to create subdirectories inside a not-yet existing directory
-(e.g., to create \verb{<tempdir>/output/outputsub} if \verb{<tempdir>/output} does not
-yet exist.
+It is \strong{not} possible to create recursive subdirectories (e.g.,
+\code{tempdir/subtempdir/otherdir}, see the \code{Examples}) because
+\link[=unlink]{removing} such directories might remove files that are still
+needed by other processes.
+
+Although the temporary directory given by \code{\link[=tempdir]{tempdir()}} will normally be
+automatically \link[=unlink]{removed} when \R \link[=quit]{quits} (and operating
+systems might
+\href{https://cran.r-project.org/doc/manuals/R-admin.html#Running-R}{periodically}
+empty the temporary directory), the created subdirectories should be removed
+once they are not needed anymore, see the section \verb{Usage in practice} below.
 }
 \section{Side effects}{
 
 The temporary directory indicated by the returned path is
-\link[=dir.create]{created}.
+\link[fs:dir_create]{created} inside \code{\link[=tempdir]{tempdir()}}.
 }
 
 \section{Usage in practice}{
 
-Examples and tests should \strong{not} write to the \link[=getwd]{working directory}
-but to a temporary directory that is cleaned up afterwards. Although
-\code{\link[=tempdir]{tempdir()}} points to a temporary directory, that directory should \strong{not} be
-removed because \href{https://posit.co/products/open-source/rstudio}{RStudio} also
-uses it. Instead, store the paths to temporary files written to \code{\link[=tempdir]{tempdir()}}
-and \link{unlink} those paths when cleaning up, or create a temporary
-subdirectory in \code{tempdir()} which can be completely be removed when cleaning
-up. \code{use_tempdir()} follows the latter approach. It is good practice to
-create the complete temporary directory with all required files and folders
-before running any example or test: this ensures no spurious matches occur if
-examples or tests are removed or added.
+\code{Examples} and \code{tests} should write to a temporary directory that is cleaned
+up afterwards (otherwise R cmd check will issue a \code{Note} about
+'\href{https://contributor.r-project.org/cran-cookbook/code_issues.html#leaving-files-in-the-temporary-directory}{detritus in the temp directory}'
+and
+\href{https://cran.r-project.org/web/packages/policies.html#Source-packages}{CRAN}
+will not accept your package). Although \code{\link[=tempdir]{tempdir()}} points to a temporary
+directory, that directory should \strong{not} be removed because other \R
+processes and \href{https://posit.co/products/open-source/rstudio}{RStudio} might
+use it. Instead, create a temporary subdirectory in \code{\link[=tempdir]{tempdir()}} and
+afterwards clean up by \link[=unlink]{removing} that subdirectory:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{my_tempdir <- create_tempdir(pattern = "subtempdir")
+< do stuff >
+unlink(my_tempdir, recursive = TRUE)
+}\if{html}{\out{</div>}}
+
+It is good practice to create the complete temporary directory with all
+required files and folders before running any test for the presence or
+absence of particular files or folders: this ensures no spurious matches
+occur if examples or tests are removed or added.
+}
+
+\section{Programming notes}{
+
+
+The output of \code{tempdir()} during
+\href{https://r-pkgs.org/R-CMD-check.html}{R CMD checks} on MacOS contains successive
+forward slashes (e.g., \verb{/var/[...]/T//RtmpxC2Fyl/working_dir/RtmpdnqgUR})
+which in earlier versions of \code{is_path()} (then in package \code{progutils}) led to
+spurious warnings about duplicated file separators.
+
 }
 
 \examples{
-tempdir()
+tempdir(check = TRUE)
 # Create a directory inside the directory returned by 'tempdir()'
-(tempdir_std <- create_tempdir(subdir = "examplesubtempdir"))
+(my_subtempdir_ex1 <- create_tempdir(pattern = "subtempdir"))
 
-# Error if the directory already exists
-try(create_tempdir(subdir = "examplesubtempdir"))
+# Using the same 'pattern' again creates another directory
+(my_subtempdir_ex2 <- create_tempdir(pattern = "subtempdir"))
 
-# It is possible to create recursive directories
-(tempdir_recursive <- create_tempdir(subdir = fs::path("abc", "def")))
+# It is not possible to create recursive subdirectories
+try(no_subtempdir <- create_tempdir(pattern = "subtempdir/otherdir"))
+try(no_subtempdir <- create_tempdir(pattern = "subtempdir\\\\otherdir"))
 
 # Clean up
-unlink(c(tempdir_std, dirname(tempdir_recursive)), recursive = TRUE)
-rm(tempdir_recursive, tempdir_std)
+unlink(c(my_subtempdir_ex1, my_subtempdir_ex2), recursive = TRUE)
+rm(my_subtempdir_ex1, my_subtempdir_ex2)
 
 }
 \seealso{
+\code{\link[=tempfile]{tempfile()}} used in this function to create the paths for the temporary
+directory;
+\code{\link[=local]{local()}} and
+\href{https://withr.r-lib.org/reference/with_tempfile.html}{withr::local_tempdir()}
+for automated deletion of temporary directories;
 \code{\link[=create_dir]{create_dir()}} to create (non-temporary) directories;
-\code{\link[checkinput:is_path]{checkinput::is_path()}} to check if a path is valid, and the 'Note on paths'
+\code{\link[checkinput:is_path]{checkinput::is_path()}} to check if a path is valid, with the \verb{Note on paths}
 in its documentation.
 
 Other functions to handle paths and directories:


### PR DESCRIPTION
### Breaking changes
- Update `create_tempdir()`: always create a new temporary directory instead of throwing an error if `subdir` is re-used. Not allow creating recursive subdirectories: cleaning up such directories is unsafe. Rename argument `subdir` to `pattern`.