### PR TITLE
Update `GitHub Actions` workflows

### DIFF
--- a/.github/workflows/check-no-suggests.yaml
+++ b/.github/workflows/check-no-suggests.yaml
@@ -1,30 +1,27 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 
-# This workflow combines elements of check-standard.yaml and
-# check-no-suggests.yaml to check if the package functions correctly without the
-# dependencies listed in 'Suggests' which I use for documentation.
-
 # NOTE: This workflow only directly installs "hard" dependencies, i.e. Depends,
 # Imports, and LinkingTo dependencies. Notably, Suggests dependencies are never
-# installed, with the exception of testthat, knitr, and rmarkdown. The cache is
-# never used to avoid accidentally restoring a cache containing a suggested
-# dependency.
+# installed, with the exception of knitr, rcmdcheck, rmarkdown, and tinytest.
+# The cache is never used to avoid accidentally restoring a cache containing a
+# suggested dependency.
 
 # Modifications:
 # - not run GHA on 'push': it should be sufficient to run R CMD check locally
 #   before pushing and run GHA on pull requests.
-# - run GHA every Saturday on 04:23 UTC: added 'schedule: - cron: "23 4 * * 6"'
-# - enable manually triggering GHA: added 'workflow_dispatch:' at 'on:' (see
-#   https://docs.github.com/en/actions/reference/workflows-and-actions and
-#   https://docs.github.com/en/actions/how-tos/manage-workflow-runs).
+# - run GHA every Saturday on 04:23 UTC
+# - enable manually triggering GHA
 # - run GHA with the currently released version of R and R version 4.1.0 (the
 #   minimum R version required by dependency checkinput) on macOS, Windows, and
-#   Ubuntu. In addition, run GHA with the devel-version of R on Ubuntu.
+#   Ubuntu. In addition, run GHA with the development version of R on Ubuntu.
 # - allow 'tinytest' instead of 'testthat' because that is the package I use for
 #   the tests.
 
-# Need help debugging build failures? Start at
-# https://github.com/r-lib/actions#where-to-find-help
+# For help debugging build failures, see https://r-pkgs.org/R-CMD-check.html and
+# https://github.com/r-lib/actions#where-to-find-help. For more background,
+# including an explanation of the syntax used in this file, see
+# https://docs.github.com/en/actions/reference/workflows-and-actions and
+# https://docs.github.com/en/actions/how-tos/manage-workflow-runs.
 
 on:
   pull_request:
@@ -32,12 +29,12 @@ on:
       - cron: "23 4 * * 6" # run GHA every Saturday on 04:23 UTC
   workflow_dispatch: # to be able to manually trigger GHA
 
-name: R-CMD-check.yaml
+name: check-no-suggests.yaml
 
 permissions: read-all
 
 jobs:
-  R-CMD-check:
+  check-no-suggests:
     runs-on: ${{ matrix.config.os }}
 
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
@@ -59,7 +56,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -67,17 +64,16 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
-          use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           dependencies: '"hard"'
           cache: false
           extra-packages: |
-            any::rcmdcheck
-            any::tinytest
             any::knitr
+            any::rcmdcheck
             any::rmarkdown
+            any::tinytest
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -1,0 +1,62 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+
+# Modifications:
+# - not run GHA on 'push': it should be sufficient to run R CMD check locally
+#   before pushing and run GHA on pull requests.
+# - run GHA every Saturday on 04:23 UTC
+# - enable manually triggering GHA
+# - run GHA with the currently released version and the development version of R
+#   on Ubuntu.
+
+# For help debugging build failures, see https://r-pkgs.org/R-CMD-check.html and
+# https://github.com/r-lib/actions#where-to-find-help. For more background,
+# including an explanation of the syntax used in this file, see
+# https://docs.github.com/en/actions/reference/workflows-and-actions and
+# https://docs.github.com/en/actions/how-tos/manage-workflow-runs.
+
+on:
+  pull_request:
+  schedule:
+      - cron: "23 4 * * 6" # run GHA every Saturday on 04:23 UTC
+  workflow_dispatch: # to be able to manually trigger GHA
+
+name: R-CMD-check.yaml
+
+permissions: read-all
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: ubuntu-latest,  r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,  r: 'release'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,12 +1,18 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
-# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+
+# For help debugging build failures, see https://r-pkgs.org/R-CMD-check.html and
+# https://github.com/r-lib/actions#where-to-find-help. For more background,
+# including an explanation of the syntax used in this file, see
+# https://docs.github.com/en/actions/reference/workflows-and-actions and
+# https://docs.github.com/en/actions/how-tos/manage-workflow-runs.
+
 on:
   push:
-    branches: [main, master]
+    branches: [main]
   pull_request:
   release:
     types: [published]
-  workflow_dispatch:
+  workflow_dispatch: # to be able to manually trigger GHA
 
 name: pkgdown.yaml
 


### PR DESCRIPTION
Update `GitHub Actions` workflows to reflect updates to the `r-lib/actions` source. Replace `R-CMD-check` GitHub Actions workflow by separate `check-no-suggests` and `check-standard` workflows. Add some links to documentation.