### PR TITLE
progutils 0.11.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ message: 'To cite package "progutils" in publications use:'
 type: software
 license: MIT
 title: 'progutils: Programming Utilities'
-version: 0.8.0
+version: 0.10.1
 abstract: Programming Utilities of Jesse Alderliesten.
 authors:
 - family-names: Alderliesten

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: progutils
 Title: Programming Utilities
-Version: 0.10.1
+Version: 0.11.0
 Authors@R: 
     person("Jesse", "Alderliesten", , "jessealderliesten@hotmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-1132-4310"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,19 @@
+# progutils 0.11.0
+
+### Breaking changes
+- `not_in()`: allow zero-length input in `x` and `table`, returning `logical(0)`
+  for zero-length input that is absent from `table` if `value` is `FALSE`.
+- `vect_to_char()`: report the `type` instead of the `class` for zero-length
+  input and `NA`s. Not round integer values. Add examples on handling
+  zero-length input.
+- `wrap_text()`: allow `character(0)` as input to `x`, returning it unchanged,
+  with a warning. `width` now has to be a natural number.
+
+### Minor updates
+- `get_file_path()`: use `fs::dir_ls()` instead of `list.files()` to more easily
+  list only files.
+
+
 # progutils 0.10.1
 
 ### Documentation

--- a/R/are_equal.R
+++ b/R/are_equal.R
@@ -3,7 +3,7 @@
 #' Test element-wise near-equality of numeric vectors by allowing for small
 #' numeric errors to make `are_equal()` safer than [`==`][Comparison].
 #'
-#' @param x,y Numeric vectors to compare for equality.
+#' @param x,y Numeric vectors with length larger than zero to compare for equality.
 #' @inheritParams checkinput::is_natural tol
 #'
 #' @details
@@ -18,7 +18,8 @@
 #' [NaN], or [infinite values][Inf] with the same sign.
 #'
 #' @section Acknowledgement:
-#' Code `abs(x - y) < tol` was taken from `dplyr::near()`.
+#' Code `abs(x - y) < tol` was taken from
+#' [`dplyr::near()`](https://dplyr.tidyverse.org/reference/near.html).
 #'
 #' @seealso
 #' [checkinput::is_natural()] to check for element-wise near-equality to natural

--- a/R/as.numeric_safe.R
+++ b/R/as.numeric_safe.R
@@ -15,7 +15,9 @@
 #' `keep_integer` is `TRUE` and is changed to `double` if `keep_integer` is
 #' `FALSE`.
 #'
-#' `NULL` and zero-length vectors are converted to `numeric(0)`. Logical vectors
+#' `NULL` and zero-length vectors are converted to `numeric(0)`, except for
+#' `integer(0)` that is converted to `integer(0)` if `keep_integer` is `TRUE`.
+#' Logical vectors
 #' of length larger than zero are converted to a vector of `NA_real_`, with a
 #' warning.
 #'

--- a/R/check_case.R
+++ b/R/check_case.R
@@ -20,7 +20,7 @@
 #' @family functions to check equality
 #'
 #' @seealso
-#' [tolower] and [toupper] to **change** case.
+#' [tolower()] and [toupper()] to **change** case.
 #'
 #' @examples
 #' x <- c("Ee", "Ee", "LL", "Ll")

--- a/R/create_dir.R
+++ b/R/create_dir.R
@@ -21,8 +21,8 @@
 #' @returns
 #' A character string with the [absolute normalized][fs::path_abs()] path to the
 #' requested directory, returned [invisibly][invisible]. An error is thrown if
-#' the attempt to create a directory fails. This happens if `dir` points to an
-#' existing file instead of an directory.
+#' the attempt to create a directory fails, for example because `dir` points to
+#' an existing file instead of to an directory.
 #'
 #' @section Side effects:
 #' The directory indicated by the returned path is [created][create_dir()] if it

--- a/R/create_file_path.R
+++ b/R/create_file_path.R
@@ -3,7 +3,8 @@
 #' Create a file path, creating the indicated directory if it does not yet exist.
 #'
 #' @inheritParams create_dir dir add_date
-#' @param filename A character string with the file name, including the file
+#' @param filename [character string][checkinput::is_character()] with the file
+#' name, including the file
 #' extension like `.csv` or `.txt`. Should adhere to the restrictions described
 #' in [checkinput::is_path()].
 #' @param format_stamp A character string indicating the [format][strftime()] of

--- a/R/create_tempdir.R
+++ b/R/create_tempdir.R
@@ -2,7 +2,7 @@
 #'
 #' Create a new temporary directory that can safely be removed.
 #'
-#' @param pattern A [character string][checkinput::is_character()] with the
+#' @param pattern [character string][checkinput::is_character()] with the
 #' initial part of the name of the new temporary directory, only containing
 #' characters that are valid in a [path][checkinput::is_path()].
 #'
@@ -23,8 +23,9 @@
 #' automatically [removed][unlink()] when \R [quits][quit()] (and operating
 #' systems might
 #' [periodically](https://cran.r-project.org/doc/manuals/R-admin.html#Running-R)
-#' empty the temporary directory), the created subdirectories should be removed
-#' once they are not needed anymore, see the section `Usage in practice` below.
+#' empty the temporary directory), the created subdirectories should be
+#' [removed][unlink()] once they are not needed anymore, see the section
+#' `Usage in practice` below.
 #'
 #' @returns
 #' The [absolute normalized][fs::path_abs()] path to the created temporary

--- a/R/get_file_path.R
+++ b/R/get_file_path.R
@@ -3,9 +3,10 @@
 #' Check that only one file in a directory has a name matching `pattern`, for
 #' example before attempting to [read a file][utils::read.table()].
 #'
-#' @param dir Character string with the [path][checkinput::is_path()] to a
-#' directory.
-#' @param pattern Character string containing a [regular expression][base::regex]
+#' @param dir [character string][checkinput::is_character()] containing the
+#' [path][checkinput::is_path()] to a directory.
+#' @param pattern [character string][checkinput::is_character()] containing a
+#' [regular expression][base::regex]
 #' used to select names of files that are present in `dir`.
 #' @param ignore_case `TRUE` or `FALSE`: use case-insensitive pattern matching?
 #' @param quietly `TRUE` or `FALSE`: suppress the message with the found file
@@ -33,8 +34,9 @@
 #' [checkinput::is_path()] to check if a path is valid, and the `Note on paths`
 #' in its documentation;
 #' [create_dir()] to create a directory if does not yet exist;
-#' [file.exists()] and [list.files()] to check for existence of files without
-#' checking they are a unique match to a pattern;
+#' [fs::file_exists()] and [list.files()] (which **includes** directories) to
+#' check for existence of files without checking they are a unique match to a
+#' pattern;
 #' [file.info()] and [file.access()] to extract information about files or
 #' directories;
 #' [fs::path()] to construct file paths in a platform-independent way;
@@ -107,7 +109,7 @@ get_file_path <- function(dir = ".", pattern, ignore_case = TRUE,
   if(length(files_present) == 0L) {
     if(!ignore_case) {
       # Check if any case-insensitive match is present
-      match_case_insensitive <-   files_present <- fs::path_abs(
+      match_case_insensitive <- fs::path_abs(
         fs::dir_ls(path = dir, all = TRUE, recurse = FALSE, type = "file",
                    regexp = pattern, fail = FALSE, ignore.case = TRUE)
       )

--- a/R/get_file_path.R
+++ b/R/get_file_path.R
@@ -89,19 +89,12 @@ get_file_path <- function(dir = ".", pattern, ignore_case = TRUE,
     stop("Directory does not exist:\n", paste_quoted(dir))
   }
 
+  # Not using list.files() because that also returns directories (even though
+  # 'include.dirs' is FALSE by default) because 'recursive' is also FALSE.
   files_present <- fs::path_abs(
-    list.files(path = dir, pattern = pattern, all.files = TRUE,
-               full.names = TRUE, ignore.case = ignore_case)
+    fs::dir_ls(path = dir, all = TRUE, recurse = FALSE, type = "file",
+               regexp = pattern, fail = FALSE, ignore.case = ignore_case)
   )
-
-  # 'list.files()' also returns directories (even though 'include.dirs' is FALSE
-  # by default) because 'recursive' is also FALSE.
-  if(length(files_present) > 0L) {
-    dirs_present <- list.dirs(path = dir, full.names = TRUE, recursive = FALSE)
-    if(length(dirs_present) > 0L) {
-      files_present <- not_in(files_present, dirs_present)
-    }
-  }
 
   msg_match <- paste0(
     if(!ignore_case) {"case-sensitive "}, "matches to pattern '",
@@ -114,8 +107,10 @@ get_file_path <- function(dir = ".", pattern, ignore_case = TRUE,
   if(length(files_present) == 0L) {
     if(!ignore_case) {
       # Check if any case-insensitive match is present
-      match_case_insensitive <- list.files(path = dir, pattern = pattern,
-                                           ignore.case = TRUE)
+      match_case_insensitive <-   files_present <- fs::path_abs(
+        fs::dir_ls(path = dir, all = TRUE, recurse = FALSE, type = "file",
+                   regexp = pattern, fail = FALSE, ignore.case = TRUE)
+      )
 
       if(length(match_case_insensitive) == 0L) {
         msg_match <- paste0(

--- a/R/not_in.R
+++ b/R/not_in.R
@@ -3,9 +3,9 @@
 #' Check that values from one vector are absent from another vector
 #'
 #' @param x Vector or factor with values to test absence from `table`. `x`
-#' should have a length larger than zero and not be of [type][typeof] `double`.
+#' should not be of [type][typeof] `double`.
 #' @param table Vector or factor in which to test for absence of `x`. `table`
-#' should have a length larger than zero and not be of `type` `double`.
+#' should not be of `type` `double`.
 #' @param value `TRUE` or `FALSE`: should a vector with values be returned
 #' instead of a boolean vector?
 #'
@@ -15,9 +15,14 @@
 #' [Factor-input][factor()] to `x` is converted to character, to prevent
 #' returning a factor with all values of `x` as [levels].
 #'
-#' [NA]s are allowed in `x` and `table` and behave the same as other values: the
-#' returned `NA`s (if `value` is `TRUE`) and the returned zero-length value (if
-#' `value` is `FALSE`) have the same type as the `NA`s in `x` if `NA`s are
+#' Zero-length input behaves slightly different from other values: `not_in()`
+#' returns `logical(0)` for zero-length input to `x` if that is absent from
+#' `table` if `value` is `FALSE`. If `value` is `TRUE`, the behaviour is normal:
+#' returning `x`.
+#'
+#' [NA] is allowed in `x` and `table` and behaves the same as other values: the
+#' returned `NA` (if `value` is `TRUE`) and the returned zero-length value (if
+#' `value` is `FALSE`) have the same type as the `NA` in `x` if `NA` is
 #' absent from `table`. `NA`s of different types in `x` and `table` match each
 #' other.
 #'
@@ -37,13 +42,7 @@
 #' such input should allow for small numerical errors by using a tolerance, for
 #' example, as the error message indicates, using [are_equal()].
 #'
-#' `not_in()` does **not** allow zero-length input because zero-length input behaves
-#' slightly different from other values: if `character(0)` is present in `x` but
-#' absent from `table`, `not_in()` would return `logical(0)` if `value` is
-#' `FALSE`. If `value` is `TRUE`, the behaviour would be normal: returning
-#' `character(0)`.
-#'
-#' Apart from **not** allowing numeric or zero-length input,
+#' Apart from **not** allowing numeric input,
 #' `not_in(x, table, value = FALSE)` is equivalent to `x %notin% table`, where
 #' `%notin%` is a function in base \R since version `4.6.0`.
 #'
@@ -77,8 +76,7 @@
 not_in <- function(x, table, value = TRUE) {
   # list input to 'x' or 'table' is not allowed because it leads to 'x' being
   # returned.
-  stopifnot(is.null(dim(x)), length(x) > 0L, is.atomic(x),
-            is.null(dim(table)), length(table) > 0L, is.atomic(table),
+  stopifnot(is.null(dim(x)), is.atomic(x), is.null(dim(table)), is.atomic(table),
             "Use are_equal() to match input of type 'double'" =
               !is.double(x) && !is.double(table),
             checkinput::is_logical(value))

--- a/R/reorder_levels.R
+++ b/R/reorder_levels.R
@@ -33,11 +33,6 @@
 #' `levels(f) <- levels(f)[<some order>]` does **not** work, see the last
 #' `Example`.
 #'
-#' @section Programming notes:
-#' Could also use an approach like
-#' `levels(x) <- list("Yes" = c("Y", "Yes"), "No" = c("N", "No"))`, see
-#' [levels()].
-#'
 #' @seealso
 #' [stats::relevel()] to assign one reference level to a factor
 #'

--- a/R/replace_vals.R
+++ b/R/replace_vals.R
@@ -31,7 +31,8 @@
 #' An error is thrown if `allow_multiple` is `FALSE` and multiple values of
 #' `old` match `x`, unless those values of `old` only differ in their case and
 #' `ignore_case` is `TRUE`. An example of such an exception is
-#' `replace_vals(x = c("a", "A"), old = c("a", "A"), new = "b", ignore_case = TRUE, allow_multiple = FALSE)`.
+#' `replace_vals(x = c("a", "A"), old = c("a", "A"), new = "b", ignore_case = TRUE, allow_multiple = FALSE)`,
+#' which returns `c("b", "b")`.
 #'
 #' If `quiet` is `FALSE`, a message indicates which values have been replaced.
 #' The order of the factor **levels** determines the order used in the message.

--- a/R/signal_text.R
+++ b/R/signal_text.R
@@ -4,7 +4,8 @@
 #'
 #' @param text Vector with text to be signalled, coerced to character by
 #' [vect_to_char()].
-#' @param signal Character string indicating the type of signal to be used:
+#' @param signal [character string][checkinput::is_character()] indicating the
+#' type of signal to be used:
 #' `"error"` to throw an [error][stop()], `"warning"` to issue a [warning],
 #' `"message"` to show a [message], or `"quiet"` to be quiet.
 #' @param origin Character string pasted behind `text` giving the origin of the

--- a/R/unpaste_unquote.R
+++ b/R/unpaste_unquote.R
@@ -1,19 +1,21 @@
 #' Create a character vector from a string with quotation marks
 #'
-#' @param x A character string
-#' @param collapse Character vector with elements that were used to collapse
+#' @param x a [character string][checkinput::is_character()].
+#' @param collapse [character string][checkinput::all_characters()] with
+#' elements that were used to collapse
 #' values when `x` was created, and are now used to [split][strsplit()] `x` on.
 #' Can be `character(0)` to leave `x` as a character string.
 #' @param quotemarks Character vector with quotation marks to be removed from
 #' `x`. Can be `character(0)` to not remove any quotation marks.
 #'
 #' @details
-#' `unpaste_unquote()` is not the exact reverse of [paste_quoted()]: it does
-#' *not* restore zero-length elements to their original value, e.g., `"'NULL'"`
+#' `unpaste_unquote()` is **not** the exact reverse of [paste_quoted()]: it does
+#' **not** restore zero-length elements to their original value, e.g., `"'NULL'"`
 #' to `NULL`, or `"'character(0)'"` to `character(0)`.
 #'
 #' @returns
-#' `x` without the quotation marks and split into a vector.
+#' `x` without the quotation marks indicated by `quotemarks`, split into a
+#' vector on `collapse`.
 #'
 #' @seealso
 #' [paste_quoted()] for the approximate opposite of `unpaste_unquote()`.

--- a/R/vect_to_char.R
+++ b/R/vect_to_char.R
@@ -14,7 +14,19 @@
 #' values into a single character string, or `NULL` to return each value as an
 #' element of a character vector.
 #'
-#' @inherit checkinput::paste_quoted details
+#' @details
+#' Some values are handled specially to better distinguish different values than
+#' [message()] etc. that use [paste0()]:
+#'
+#' - `NULL` is returned as `"NULL"`
+#' - non-`NULL` zero-length objects are returned as `"<type>(0)"` (e.g.,
+#'   `"logical(0)"`; for `numeric(0)` this is `"double(0)"`)
+#' - `""` is returned as `""`
+#' - logical `NA` is returned as `"NA"`
+#' - non-logical `NA` is returned as `"NA_<type>_"` (e.g., `"NA_character_"`;
+#'   for `NA_real_` this is `"NA_double_"`;
+#'   for [factors][factor] this is `"NA_character_"` because `vect_to_char()`
+#'   converts factors to characters).
 #'
 #' @returns
 #' The names and values in `x`, with values of numeric `x` rounded to `signif`
@@ -32,7 +44,12 @@
 #' `paste0(vect_to_char(c(table(x)), sep = " (", collapse =  "), "), ")")`,
 #' see the last `Example`.
 #'
-#' @seealso [toString()] which can be used if names of `x` can be removed.
+#' @seealso
+#' [toString()] which can be used if names of `x` can be removed;
+#' `vignette("type_coercion", package = "checkinput")` and
+#' `help("is_zerolength", package = "checkinput")` for a discussion of some
+#' issues with type conversion and zero-length input when [combining][c()]
+#' objects into a vector.
 #'
 #' @family functions to convert types
 #' @family functions to modify character vectors
@@ -52,6 +69,11 @@
 #' x_char <- c(a = "abc", b = "def", c = "this is text")
 #' vect_to_char(x = x_char) # "a: abc, b: def, c: this is text"
 #' vect_to_char(x = unname(x_char)) # "abc, def, this is some text"
+#'
+#' # Nicer handling of zero-length input
+#' vect_to_char(logical(0)) # "logical(0)"
+#' message(logical(0)) # <empty>
+#' message(vect_to_char(logical(0))) # logical(0)
 #'
 #' # Using vect_to_char() to get a frequency table
 #' x <- 1:10
@@ -74,7 +96,7 @@ vect_to_char <- function(x, signif = 3L, width = Inf, sep = ": ",
   }
   stopifnot(is.vector(x) || is.factor(x) || is.null(x))
 
-  if(is.numeric(x)) {
+  if(is.double(x)) {
     x <- signif(x = x, digits = signif)
   }
 
@@ -86,23 +108,14 @@ vect_to_char <- function(x, signif = 3L, width = Inf, sep = ": ",
     if(is.null(x)) {
       x <- "NULL"
     } else {
-      x <- paste0(class(x), "(0)")
+      x <- paste0(typeof(x), "(0)")
     }
   }
 
-  bool_NA <- is.na(x) & !is.nan(x)
-  if(any(bool_NA)) {
-    if(!is.list(x)) {
-      if(!is.logical(x)) {
-        x[bool_NA] <- paste0("NA_", class(x), "_")
-      }
-    } else {
-      NA_new <- paste0("NA_",
-                       vapply(X = x[bool_NA], FUN = class,
-                              FUN.VALUE = character(1), USE.NAMES = FALSE),
-                       "_")
-      NA_new[NA_new == "NA_logical_"] <- "NA"
-      x[bool_NA] <- NA_new
+  if(!is.logical(x)) {
+    bool_NA <- is.na(x) & !is.nan(x)
+    if(any(bool_NA)) {
+      x[bool_NA] <- paste0("NA_", typeof(x), "_")
     }
   }
 

--- a/R/vect_to_char.R
+++ b/R/vect_to_char.R
@@ -8,11 +8,11 @@
 #' through `unlist(x, use.names = TRUE)`, with a warning).
 #' @param signif Positive number of length one, rounded to the nearest positive
 #' integer indicating the number of significant digits to round numeric `x` to.
-#' @param sep Character string of length one used to separate the names and the
-#' values. Ignored if `x` does not have names.
-#' @param collapse Character string of length one to collapse values into a
-#' single character string, or `NULL` to return each value as an element of a
-#' character vector.
+#' @param sep [character string][checkinput::is_character()] used to separate
+#' the names and the values. Ignored if `x` does not have names.
+#' @param collapse [character string][checkinput::is_character()] to collapse
+#' values into a single character string, or `NULL` to return each value as an
+#' element of a character vector.
 #'
 #' @inherit checkinput::paste_quoted details
 #'

--- a/R/wrap_text.R
+++ b/R/wrap_text.R
@@ -2,13 +2,16 @@
 #'
 #' Wrap text at blank characters to achieve a maximum line width.
 #'
-#' @param x Character vector to be wrapped.
-#' @param width A positive number giving the maximum line width (in characters)
+#' @param x [character vector][checkinput::all_characters()] to be wrapped.
+#' @param width [natural number][checkinput::is_natural()] giving the maximum
+#' line width (in characters)
 #' after wrapping. Can be `Inf` to not wrap text.
 #' @param ignore_newlines `TRUE` or `FALSE`: should newlines in `x` be replaced
-#' by a blank character?
+#' by blank characters?
 #'
 #' @details
+#' `character(0)` input to `x` is returned unchanged, with a warning.
+#'
 #' `x` of length larger than one is pasted into a single string, separating the
 #' parts by blank characters.
 #'
@@ -59,9 +62,16 @@
 #'
 #' @export
 wrap_text <- function(x, width = 80L, ignore_newlines = TRUE) {
-  stopifnot(checkinput::all_characters(x, allow_empty = TRUE),
-            checkinput::is_positive(width),
-            checkinput::is_logical(ignore_newlines))
+  stopifnot(
+    checkinput::all_characters(x, allow_empty = TRUE, allow_zerolength = TRUE),
+    checkinput::is_logical(ignore_newlines))
+  if(!is.infinite(width)) {
+    width <- checkinput::make_natural(width)
+  }
+  if(length(x) == 0L) {
+    warning("'x' is 'character(0)'")
+    return(x)
+  }
   if(length(x) > 1L) {
     x <- paste0(x, collapse = " ")
   }

--- a/README.Rmd
+++ b/README.Rmd
@@ -22,8 +22,8 @@ knitr::opts_chunk$set(
 equality, construct messages, or handle files and directories.
 
 ## Installation
-Visit the [progutils website](https://jessealderliesten.github.io/progutils/) to
-explore the package, or install `progutils` from
+Visit the [`progutils` website](https://jessealderliesten.github.io/progutils/)
+to explore the package, or install `progutils` from
 [GitHub](https://github.com/JesseAlderliesten/progutils) using the following
 R code (you need to run R as administrator):
 
@@ -38,7 +38,7 @@ remotes::install_github(repo = "JesseAlderliesten/progutils",
 ```
 
 For more information about installing and configuring R and RStudio, see my
-package [checkrpkgs](https://jessealderliesten.github.io/checkrpkgs/).
+package [`checkrpkgs`](https://jessealderliesten.github.io/checkrpkgs/).
 
 
 ## Examples
@@ -55,7 +55,7 @@ as.numeric(x) # Returns the indices instead of the values!
 as.numeric_safe(x) # Returns the values.
 ```
 
-Similarly, using `relevel` or `levels()` from base R to reorder factor levels
+Similarly, using `relevel()` or `levels()` from base R to reorder factor levels
 does **not** work, whereas using `reorder_levels()` from `progutils` **does**:
 
 ```{r reorder_levels}

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ License](LICENSE.md).
     To cite package 'progutils' in publications use:
 
       Alderliesten J (2026). _progutils: Programming Utilities_. R package
-      version 0.10.1, <https://github.com/JesseAlderliesten/progutils>.
+      version 0.11.0, <https://github.com/JesseAlderliesten/progutils>.
 
     A BibTeX entry for LaTeX users is
 
@@ -115,7 +115,7 @@ License](LICENSE.md).
         title = {progutils: Programming Utilities},
         author = {Jesse Alderliesten},
         year = {2026},
-        note = {R package version 0.10.1},
+        note = {R package version 0.11.0},
         url = {https://github.com/JesseAlderliesten/progutils},
       }
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ check equality, construct messages, or handle files and directories.
 
 ## Installation
 
-Visit the [progutils
+Visit the [`progutils`
 website](https://jessealderliesten.github.io/progutils/) to explore the
 package, or install `progutils` from
 [GitHub](https://github.com/JesseAlderliesten/progutils) using the
@@ -31,7 +31,7 @@ remotes::install_github(repo = "JesseAlderliesten/progutils",
 
 For more information about installing and configuring R and RStudio, see
 my package
-[checkrpkgs](https://jessealderliesten.github.io/checkrpkgs/).
+[`checkrpkgs`](https://jessealderliesten.github.io/checkrpkgs/).
 
 ## Examples
 
@@ -52,7 +52,7 @@ as.numeric_safe(x) # Returns the values.
 #> [1] 11 12 13
 ```
 
-Similarly, using `relevel` or `levels()` from base R to reorder factor
+Similarly, using `relevel()` or `levels()` from base R to reorder factor
 levels does **not** work, whereas using `reorder_levels()` from
 `progutils` **does**:
 

--- a/inst/tinytest/test_not_in.R
+++ b/inst/tinytest/test_not_in.R
@@ -114,36 +114,93 @@ for(value in c(TRUE, FALSE)) {
     not_in(x = c("a", "b"), table = NA_character_, value = value),
     if(value) {c("a", "b")} else {c(TRUE, TRUE)})
 
-  # 3g (zero-length value in x, normal character value in table)
-  expect_error(
-    not_in(x = character(0), table = c("a", "b"), value = value),
-    pattern = "length(x) > 0L is not TRUE", fixed = TRUE)
-
-  # 3h (normal character values in x, zero-length value in table)
-  expect_error(
-    not_in(x = c("a", "b"), table = character(0), value = value),
-    pattern = "length(table) > 0L is not TRUE", fixed = TRUE)
-
-  # 3i (empty quotes behave normally)
+  # empty quotes behave normally
   expect_identical(
     not_in(x = "", table = c("a", "b"), value = value),
     if(value) {""} else {TRUE})
 
-  # 3j (empty quotes behave normally)
+  # empty quotes behave normally
   expect_identical(
     not_in(x = c("a", "b"), table = "", value = value),
     if(value) {c("a", "b")} else {c(TRUE, TRUE)})
 
-  # 3k (empty quotes behave normally)
+  # empty quotes behave normally
   expect_identical(
     not_in(x = c("a", "", "b"), table = "", value = value),
     if(value) {c("a", "b")} else {c(TRUE, FALSE, TRUE)})
 
-  # 3l (empty quotes behave normally)
+  # empty quotes behave normally
   expect_identical(
     not_in(x = "", table = "", value = value),
     if(value) {character(0)} else {FALSE})
 }
+
+# zero-length value in x, 'value' is FALSE
+expect_identical(
+  not_in(x = character(0), table = c("a", "b"), value = FALSE),
+  logical(0))
+
+expect_identical(
+  not_in(x = logical(0), table = c("a", "b"), value = FALSE),
+  logical(0))
+
+expect_identical(
+  not_in(x = character(0), table = character(0), value = FALSE),
+  logical(0))
+
+expect_identical(
+  not_in(x = logical(0), table = logical(0), value = FALSE),
+  logical(0))
+
+expect_identical(
+  not_in(x = character(0), table = logical(0), value = FALSE),
+  logical(0))
+
+expect_identical(
+  not_in(x = logical(0), table = character(0), value = FALSE),
+  logical(0))
+
+# 3g_p2 (zero-length value in x, 'value' is TRUE)
+expect_identical(
+  not_in(x = character(0), table = c("a", "b"), value = TRUE),
+  character(0))
+
+expect_identical(
+  not_in(x = logical(0), table = c("a", "b"), value = TRUE),
+  logical(0))
+
+expect_identical(
+  not_in(x = character(0), table = character(0), value = TRUE),
+  character(0))
+
+expect_identical(
+  not_in(x = logical(0), table = logical(0), value = TRUE),
+  logical(0))
+
+expect_identical(
+  not_in(x = character(0), table = logical(0), value = TRUE),
+  character(0))
+
+expect_identical(
+  not_in(x = logical(0), table = character(0), value = TRUE),
+  logical(0))
+
+# zero-length value in table
+expect_identical(
+  not_in(x = c("a", "b"), table = character(0), value = FALSE),
+  c(TRUE, TRUE))
+
+expect_identical(
+  not_in(x = c("a", "b"), table = logical(0), value = FALSE),
+  c(TRUE, TRUE))
+
+expect_identical(
+  not_in(x = c("a", "b"), table = character(0), value = TRUE),
+  c("a", "b"))
+
+expect_identical(
+  not_in(x = c("a", "b"), table = logical(0), value = TRUE),
+  c("a", "b"))
 
 ##### Factor input to 'x' or 'table' #####
 # Factor input to 'x' is converted to character, factor input to 'table' behaves

--- a/inst/tinytest/test_replace_vals.R
+++ b/inst/tinytest/test_replace_vals.R
@@ -75,6 +75,14 @@ expect_error(
   pattern = paste0(warn_mult_old, "'m', 'l') matched 'x' (", x_quoted,
                    "): 'l', 'm'"), fixed = TRUE)
 
+#### Test other sections ####
+expect_message(
+expect_identical(
+  replace_vals(x = c("a", "A"), old = c("a", "A"), new = "b",
+               ignore_case = TRUE, allow_multiple = FALSE),
+  c("b", "b")
+  ), pattern = "Replaced values", strict = TRUE, fixed = TRUE
+)
 
 #### Tests ####
 ##### ignore_case #####

--- a/inst/tinytest/test_vect_to_char.R
+++ b/inst/tinytest/test_vect_to_char.R
@@ -33,6 +33,12 @@ expect_identical(
 expect_identical(vect_to_char(x = x_in_char), x_out_char)
 expect_identical(vect_to_char(x = unname(x_in_char)), "abc, def, this is text")
 
+expect_identical(vect_to_char(logical(0)), "logical(0)")
+expect_message(message(logical(0)), pattern = "")
+expect_message(message(vect_to_char(logical(0))),
+               pattern = "logical(0)", strict = TRUE, fixed = TRUE)
+
+
 expect_identical(
   paste0(vect_to_char(c(table(c(c, d))), sep = " (", collapse =  "), "), ")"),
   paste0("1 (1), 2 (1), 3 (1), 4 (1), 5 (2), 6 (2), 7 (2), 8 (2), 9 (2),",
@@ -40,10 +46,19 @@ expect_identical(
 
 
 #### Tests ####
-expect_silent(expect_identical(vect_to_char(NULL), "NULL"))
-expect_silent(expect_identical(vect_to_char(numeric(0)), "numeric(0)"))
-expect_silent(expect_identical(vect_to_char(c("a", "", "c", NA_character_)),
-                               "a, \"\", c, NA_character_"))
+expect_identical(vect_to_char(x = NULL), "NULL")
+expect_identical(vect_to_char(x = character(0L)), "character(0)")
+expect_identical(vect_to_char(x = logical(0L)), "logical(0)")
+expect_identical(vect_to_char(x = numeric(0)), "double(0)")
+expect_identical(vect_to_char(x = double(0L)), "double(0)")
+expect_identical(vect_to_char(x = integer(0L)), "integer(0)")
+expect_identical(vect_to_char(x = c("a", "", "c", NA_character_)),
+                 "a, \"\", c, NA_character_")
+
+expect_identical(vect_to_char(x = NA), "NA")
+expect_identical(vect_to_char(x = NA_character_), "NA_character_")
+expect_identical(vect_to_char(x = NA_real_), "NA_double_")
+expect_identical(vect_to_char(x = NA_integer_), "NA_integer_")
 
 expect_silent(expect_identical(vect_to_char(as.factor(NULL)), "character(0)"))
 expect_silent(expect_identical(vect_to_char(as.factor(numeric(0))), "character(0)"))
@@ -97,7 +112,7 @@ expect_silent(expect_identical(
 expect_silent(
   expect_identical(
     vect_to_char(x = x_in_InfNa),
-    paste0("am: -1, bm: -2, i: 9, l: NA_numeric_, m: NaN,",
+    paste0("am: -1, bm: -2, i: 9, l: NA_double_, m: NaN,",
            " n: Inf, o: -Inf, j: 10, z: 26, a: 1, b: 2, c: 3")
   )
 )
@@ -114,7 +129,7 @@ expect_silent(expect_identical(vect_to_char(x = x_fact_num),
 
 expect_warning(expect_identical(
   vect_to_char(x = list(x_in_InfNa, b, unname(b)), signif = 2),
-  paste0("am: -1, bm: -2, i: 9, l: NA_numeric_, m: NaN, n: Inf, o: -Inf, j: 10, z: 26,",
+  paste0("am: -1, bm: -2, i: 9, l: NA_double_, m: NaN, n: Inf, o: -Inf, j: 10, z: 26,",
          " a: 1, b: 2, c: 3, a: 0.14, b: 0.29, c: 0.43, : 0.14, : 0.29, : 0.43")),
   pattern = "Unlisted 'x' to obtain a vector!", strict = TRUE)
 

--- a/inst/tinytest/test_wrap_text.R
+++ b/inst/tinytest/test_wrap_text.R
@@ -218,6 +218,16 @@ expect_warning(expect_identical(
   pattern = paste0("Width of 3 text fragments (15, 13, 11 characters) exceeds",
                    " 'width' (10 characters)"), strict = TRUE, fixed = TRUE)
 
+##### zero-length x #####
+expect_error(
+  wrap_text(NULL),
+  pattern = "all_characters(x, allow_empty = TRUE, allow_zerolength = TRUE)",
+  fixed = TRUE)
+
+expect_warning(
+  expect_identical(wrap_text(character(0)), character(0)),
+  pattern = "'x' is 'character(0)'", strict = TRUE, fixed = TRUE)
+
 ##### x of length > 1 #####
 expect_identical(
   wrap_text(x = letters[1:3], width = Inf), "a b c")
@@ -239,10 +249,14 @@ expect_identical(
   wrap_text(x = x_nonspace_blanks, width = 11L, ignore_newlines = FALSE),
   "123\f567\n911 141\f719\n123 262 931")
 
-##### Error for width < 6L #####
+##### width #####
 expect_error(
   wrap_text(x = x, width = 0L),
-  pattern = "is_positive(width) is not TRUE", fixed = TRUE)
+  pattern = "is_natural(width) is not TRUE", fixed = TRUE)
+
+expect_error(
+  wrap_text(x = x, width = 10.1),
+  pattern = "is_natural(width) is not TRUE", fixed = TRUE)
 
 expect_warning(expect_identical(
   wrap_text(x = x, width = 1L), "123\n567\n911\n141\n719\n123\n262\n931"),

--- a/man/are_equal.Rd
+++ b/man/are_equal.Rd
@@ -7,7 +7,7 @@
 are_equal(x, y, tol = sqrt(.Machine$double.eps))
 }
 \arguments{
-\item{x, y}{Numeric vectors to compare for equality.}
+\item{x, y}{Numeric vectors with length larger than zero to compare for equality.}
 
 \item{tol}{A small \link[checkinput:is_positive]{positive} number. Numbers that differ less
 than \code{tol} are considered equal.}
@@ -30,7 +30,8 @@ but tests exact equality.
 }
 \section{Acknowledgement}{
 
-Code \code{abs(x - y) < tol} was taken from \code{dplyr::near()}.
+Code \code{abs(x - y) < tol} was taken from
+\href{https://dplyr.tidyverse.org/reference/near.html}{\code{dplyr::near()}}.
 }
 
 \examples{

--- a/man/as.numeric_safe.Rd
+++ b/man/as.numeric_safe.Rd
@@ -25,7 +25,9 @@ The \link[=typeof]{type} of \link[=integer]{integers} is kept \code{integer} if
 \code{keep_integer} is \code{TRUE} and is changed to \code{double} if \code{keep_integer} is
 \code{FALSE}.
 
-\code{NULL} and zero-length vectors are converted to \code{numeric(0)}. Logical vectors
+\code{NULL} and zero-length vectors are converted to \code{numeric(0)}, except for
+\code{integer(0)} that is converted to \code{integer(0)} if \code{keep_integer} is \code{TRUE}.
+Logical vectors
 of length larger than zero are converted to a vector of \code{NA_real_}, with a
 warning.
 

--- a/man/check_case.Rd
+++ b/man/check_case.Rd
@@ -9,7 +9,8 @@ check_case(x, signal = c("error", "warning", "message", "quiet"))
 \arguments{
 \item{x}{Character vector to check.}
 
-\item{signal}{Character string indicating the type of signal to be used:
+\item{signal}{\link[checkinput:is_character]{character string} indicating the
+type of signal to be used:
 \code{"error"} to throw an \link[=stop]{error}, \code{"warning"} to issue a \link{warning},
 \code{"message"} to show a \link{message}, or \code{"quiet"} to be quiet.}
 }
@@ -39,7 +40,7 @@ check_case(x = x, signal = "warning")
 
 }
 \seealso{
-\link{tolower} and \link{toupper} to \strong{change} case.
+\code{\link[=tolower]{tolower()}} and \code{\link[=toupper]{toupper()}} to \strong{change} case.
 
 Other functions to check equality:
 \code{\link[=are_equal]{are_equal()}},

--- a/man/create_dir.Rd
+++ b/man/create_dir.Rd
@@ -20,8 +20,8 @@ current date in the \link[=strftime]{format} \code{YYYY_mm_dd}?}
 \value{
 A character string with the \link[fs:path_abs]{absolute normalized} path to the
 requested directory, returned \link[=invisible]{invisibly}. An error is thrown if
-the attempt to create a directory fails. This happens if \code{dir} points to an
-existing file instead of an directory.
+the attempt to create a directory fails, for example because \code{dir} points to
+an existing file instead of to an directory.
 }
 \description{
 Create a directory if it does not yet exist.

--- a/man/create_file_path.Rd
+++ b/man/create_file_path.Rd
@@ -12,7 +12,8 @@ create_file_path(
 )
 }
 \arguments{
-\item{filename}{A character string with the file name, including the file
+\item{filename}{\link[checkinput:is_character]{character string} with the file
+name, including the file
 extension like \code{.csv} or \code{.txt}. Should adhere to the restrictions described
 in \code{\link[checkinput:is_path]{checkinput::is_path()}}.}
 

--- a/man/create_tempdir.Rd
+++ b/man/create_tempdir.Rd
@@ -7,7 +7,7 @@
 create_tempdir(pattern = "tempdir")
 }
 \arguments{
-\item{pattern}{A \link[checkinput:is_character]{character string} with the
+\item{pattern}{\link[checkinput:is_character]{character string} with the
 initial part of the name of the new temporary directory, only containing
 characters that are valid in a \link[checkinput:is_path]{path}.}
 }
@@ -35,8 +35,9 @@ Although the temporary directory given by \code{\link[=tempdir]{tempdir()}} will
 automatically \link[=unlink]{removed} when \R \link[=quit]{quits} (and operating
 systems might
 \href{https://cran.r-project.org/doc/manuals/R-admin.html#Running-R}{periodically}
-empty the temporary directory), the created subdirectories should be removed
-once they are not needed anymore, see the section \verb{Usage in practice} below.
+empty the temporary directory), the created subdirectories should be
+\link[=unlink]{removed} once they are not needed anymore, see the section
+\verb{Usage in practice} below.
 }
 \section{Side effects}{
 

--- a/man/get_file_path.Rd
+++ b/man/get_file_path.Rd
@@ -7,10 +7,11 @@
 get_file_path(dir = ".", pattern, ignore_case = TRUE, quietly = FALSE)
 }
 \arguments{
-\item{dir}{Character string with the \link[checkinput:is_path]{path} to a
-directory.}
+\item{dir}{\link[checkinput:is_character]{character string} containing the
+\link[checkinput:is_path]{path} to a directory.}
 
-\item{pattern}{Character string containing a \link[base:regex]{regular expression}
+\item{pattern}{\link[checkinput:is_character]{character string} containing a
+\link[base:regex]{regular expression}
 used to select names of files that are present in \code{dir}.}
 
 \item{ignore_case}{\code{TRUE} or \code{FALSE}: use case-insensitive pattern matching?}
@@ -79,8 +80,9 @@ rm(my_tempfiles)
 \code{\link[checkinput:is_path]{checkinput::is_path()}} to check if a path is valid, and the \verb{Note on paths}
 in its documentation;
 \code{\link[=create_dir]{create_dir()}} to create a directory if does not yet exist;
-\code{\link[=file.exists]{file.exists()}} and \code{\link[=list.files]{list.files()}} to check for existence of files without
-checking they are a unique match to a pattern;
+\code{\link[fs:file_exists]{fs::file_exists()}} and \code{\link[=list.files]{list.files()}} (which \strong{includes} directories) to
+check for existence of files without checking they are a unique match to a
+pattern;
 \code{\link[=file.info]{file.info()}} and \code{\link[=file.access]{file.access()}} to extract information about files or
 directories;
 \code{\link[fs:path]{fs::path()}} to construct file paths in a platform-independent way;

--- a/man/not_in.Rd
+++ b/man/not_in.Rd
@@ -8,10 +8,10 @@ not_in(x, table, value = TRUE)
 }
 \arguments{
 \item{x}{Vector or factor with values to test absence from \code{table}. \code{x}
-should have a length larger than zero and not be of \link[=typeof]{type} \code{double}.}
+should not be of \link[=typeof]{type} \code{double}.}
 
 \item{table}{Vector or factor in which to test for absence of \code{x}. \code{table}
-should have a length larger than zero and not be of \code{type} \code{double}.}
+should not be of \code{type} \code{double}.}
 
 \item{value}{\code{TRUE} or \code{FALSE}: should a vector with values be returned
 instead of a boolean vector?}
@@ -32,9 +32,14 @@ Duplicates in \code{x} are kept, in contrast to \code{\link[=setdiff]{setdiff()}
 \link[=factor]{Factor-input} to \code{x} is converted to character, to prevent
 returning a factor with all values of \code{x} as \link{levels}.
 
-\link{NA}s are allowed in \code{x} and \code{table} and behave the same as other values: the
-returned \code{NA}s (if \code{value} is \code{TRUE}) and the returned zero-length value (if
-\code{value} is \code{FALSE}) have the same type as the \code{NA}s in \code{x} if \code{NA}s are
+Zero-length input behaves slightly different from other values: \code{not_in()}
+returns \code{logical(0)} for zero-length input to \code{x} if that is absent from
+\code{table} if \code{value} is \code{FALSE}. If \code{value} is \code{TRUE}, the behaviour is normal:
+returning \code{x}.
+
+\link{NA} is allowed in \code{x} and \code{table} and behaves the same as other values: the
+returned \code{NA} (if \code{value} is \code{TRUE}) and the returned zero-length value (if
+\code{value} is \code{FALSE}) have the same type as the \code{NA} in \code{x} if \code{NA} is
 absent from \code{table}. \code{NA}s of different types in \code{x} and \code{table} match each
 other.
 
@@ -48,13 +53,7 @@ matching
 such input should allow for small numerical errors by using a tolerance, for
 example, as the error message indicates, using \code{\link[=are_equal]{are_equal()}}.
 
-\code{not_in()} does \strong{not} allow zero-length input because zero-length input behaves
-slightly different from other values: if \code{character(0)} is present in \code{x} but
-absent from \code{table}, \code{not_in()} would return \code{logical(0)} if \code{value} is
-\code{FALSE}. If \code{value} is \code{TRUE}, the behaviour would be normal: returning
-\code{character(0)}.
-
-Apart from \strong{not} allowing numeric or zero-length input,
+Apart from \strong{not} allowing numeric input,
 \code{not_in(x, table, value = FALSE)} is equivalent to \code{x \%notin\% table}, where
 \verb{\%notin\%} is a function in base \R since version \verb{4.6.0}.
 }

--- a/man/reorder_levels.Rd
+++ b/man/reorder_levels.Rd
@@ -47,13 +47,6 @@ Reordering levels of factor \code{f} by replacing levels through code like
 \code{Example}.
 }
 
-\section{Programming notes}{
-
-Could also use an approach like
-\code{levels(x) <- list("Yes" = c("Y", "Yes"), "No" = c("N", "No"))}, see
-\code{\link[=levels]{levels()}}.
-}
-
 \examples{
 orig <- factor(letters[c(12:13, 13:11)], levels = letters[13:11])
 orig

--- a/man/replace_vals.Rd
+++ b/man/replace_vals.Rd
@@ -64,7 +64,8 @@ argument \code{signal_case_new}.
 An error is thrown if \code{allow_multiple} is \code{FALSE} and multiple values of
 \code{old} match \code{x}, unless those values of \code{old} only differ in their case and
 \code{ignore_case} is \code{TRUE}. An example of such an exception is
-\code{replace_vals(x = c("a", "A"), old = c("a", "A"), new = "b", ignore_case = TRUE, allow_multiple = FALSE)}.
+\code{replace_vals(x = c("a", "A"), old = c("a", "A"), new = "b", ignore_case = TRUE, allow_multiple = FALSE)},
+which returns \code{c("b", "b")}.
 
 If \code{quiet} is \code{FALSE}, a message indicates which values have been replaced.
 The order of the factor \strong{levels} determines the order used in the message.

--- a/man/signal_text.Rd
+++ b/man/signal_text.Rd
@@ -14,7 +14,8 @@ signal_text(
 \item{text}{Vector with text to be signalled, coerced to character by
 \code{\link[=vect_to_char]{vect_to_char()}}.}
 
-\item{signal}{Character string indicating the type of signal to be used:
+\item{signal}{\link[checkinput:is_character]{character string} indicating the
+type of signal to be used:
 \code{"error"} to throw an \link[=stop]{error}, \code{"warning"} to issue a \link{warning},
 \code{"message"} to show a \link{message}, or \code{"quiet"} to be quiet.}
 

--- a/man/unpaste_unquote.Rd
+++ b/man/unpaste_unquote.Rd
@@ -7,9 +7,10 @@
 unpaste_unquote(x, collapse = c(", ", "; "), quotemarks = c("'", "\\""))
 }
 \arguments{
-\item{x}{A character string}
+\item{x}{a \link[checkinput:is_character]{character string}.}
 
-\item{collapse}{Character vector with elements that were used to collapse
+\item{collapse}{\link[checkinput:all_characters]{character string} with
+elements that were used to collapse
 values when \code{x} was created, and are now used to \link[=strsplit]{split} \code{x} on.
 Can be \code{character(0)} to leave \code{x} as a character string.}
 
@@ -17,14 +18,15 @@ Can be \code{character(0)} to leave \code{x} as a character string.}
 \code{x}. Can be \code{character(0)} to not remove any quotation marks.}
 }
 \value{
-\code{x} without the quotation marks and split into a vector.
+\code{x} without the quotation marks indicated by \code{quotemarks}, split into a
+vector on \code{collapse}.
 }
 \description{
 Create a character vector from a string with quotation marks
 }
 \details{
-\code{unpaste_unquote()} is not the exact reverse of \code{\link[=paste_quoted]{paste_quoted()}}: it does
-\emph{not} restore zero-length elements to their original value, e.g., \code{"'NULL'"}
+\code{unpaste_unquote()} is \strong{not} the exact reverse of \code{\link[=paste_quoted]{paste_quoted()}}: it does
+\strong{not} restore zero-length elements to their original value, e.g., \code{"'NULL'"}
 to \code{NULL}, or \code{"'character(0)'"} to \code{character(0)}.
 }
 \examples{

--- a/man/vect_to_char.Rd
+++ b/man/vect_to_char.Rd
@@ -20,18 +20,19 @@ through \code{unlist(x, use.names = TRUE)}, with a warning).}
 \item{signif}{Positive number of length one, rounded to the nearest positive
 integer indicating the number of significant digits to round numeric \code{x} to.}
 
-\item{width}{A positive number giving the maximum line width (in characters)
+\item{width}{\link[checkinput:is_natural]{natural number} giving the maximum
+line width (in characters)
 after wrapping. Can be \code{Inf} to not wrap text.}
 
-\item{sep}{Character string of length one used to separate the names and the
-values. Ignored if \code{x} does not have names.}
+\item{sep}{\link[checkinput:is_character]{character string} used to separate
+the names and the values. Ignored if \code{x} does not have names.}
 
-\item{collapse}{Character string of length one to collapse values into a
-single character string, or \code{NULL} to return each value as an element of a
-character vector.}
+\item{collapse}{\link[checkinput:is_character]{character string} to collapse
+values into a single character string, or \code{NULL} to return each value as an
+element of a character vector.}
 
 \item{ignore_newlines}{\code{TRUE} or \code{FALSE}: should newlines in \code{x} be replaced
-by a blank character?}
+by blank characters?}
 }
 \value{
 The names and values in \code{x}, with values of numeric \code{x} rounded to \code{signif}
@@ -49,10 +50,16 @@ Convert a vector to a character string while preserving names and rounding
 numeric values.
 }
 \details{
-\code{NULL} is returned as \code{"'NULL'"}, other zero-length objects are returned as
-\code{"'<class>(0)'"} (e.g., \code{"'logical(0)'"}), \code{""} as \code{'""'}, logical \code{NA} as
-\code{"'NA'"}, and non-logical \code{NA}s as \code{"'NA_<class>_'"} (e.g., \code{"'NA_real_'"};
+Some values are handled specially to make them print clearer:
+\itemize{
+\item \code{NULL} is returned as \code{"'NULL'"}
+\item non-\code{NULL} zero-length objects are returned as \code{"'<class>(0)'"} (e.g.,
+\code{"'logical(0)'"})
+\item \code{""} is returned as \code{'""'}
+\item logical \code{NA} is returned as \code{"'NA'"}
+\item non-logical \code{NA} is returned as \code{"'NA_<class>_'"} (e.g., \code{"'NA_real_'"};
 for \link[=factor]{factors} this is \code{"'NA_character_'"}).
+}
 }
 \section{Programming notes}{
 

--- a/man/vect_to_char.Rd
+++ b/man/vect_to_char.Rd
@@ -50,15 +50,18 @@ Convert a vector to a character string while preserving names and rounding
 numeric values.
 }
 \details{
-Some values are handled specially to make them print clearer:
+Some values are handled specially to better distinguish different values than
+\code{\link[=message]{message()}} etc. that use \code{\link[=paste0]{paste0()}}:
 \itemize{
-\item \code{NULL} is returned as \code{"'NULL'"}
-\item non-\code{NULL} zero-length objects are returned as \code{"'<class>(0)'"} (e.g.,
-\code{"'logical(0)'"})
-\item \code{""} is returned as \code{'""'}
-\item logical \code{NA} is returned as \code{"'NA'"}
-\item non-logical \code{NA} is returned as \code{"'NA_<class>_'"} (e.g., \code{"'NA_real_'"};
-for \link[=factor]{factors} this is \code{"'NA_character_'"}).
+\item \code{NULL} is returned as \code{"NULL"}
+\item non-\code{NULL} zero-length objects are returned as \code{"<type>(0)"} (e.g.,
+\code{"logical(0)"}; for \code{numeric(0)} this is \code{"double(0)"})
+\item \code{""} is returned as \code{""}
+\item logical \code{NA} is returned as \code{"NA"}
+\item non-logical \code{NA} is returned as \code{"NA_<type>_"} (e.g., \code{"NA_character_"};
+for \code{NA_real_} this is \code{"NA_double_"};
+for \link[=factor]{factors} this is \code{"NA_character_"} because \code{vect_to_char()}
+converts factors to characters).
 }
 }
 \section{Programming notes}{
@@ -83,6 +86,11 @@ x_char <- c(a = "abc", b = "def", c = "this is text")
 vect_to_char(x = x_char) # "a: abc, b: def, c: this is text"
 vect_to_char(x = unname(x_char)) # "abc, def, this is some text"
 
+# Nicer handling of zero-length input
+vect_to_char(logical(0)) # "logical(0)"
+message(logical(0)) # <empty>
+message(vect_to_char(logical(0))) # logical(0)
+
 # Using vect_to_char() to get a frequency table
 x <- 1:10
 names(x) <- letters[x]
@@ -93,7 +101,11 @@ paste0(vect_to_char(c(table(x)), sep = " (", collapse =  "), "), ")")
 
 }
 \seealso{
-\code{\link[=toString]{toString()}} which can be used if names of \code{x} can be removed.
+\code{\link[=toString]{toString()}} which can be used if names of \code{x} can be removed;
+\code{vignette("type_coercion", package = "checkinput")} and
+\code{help("is_zerolength", package = "checkinput")} for a discussion of some
+issues with type conversion and zero-length input when \link[=c]{combining}
+objects into a vector.
 
 Other functions to convert types:
 \code{\link[=as.numeric_safe]{as.numeric_safe()}},

--- a/man/wrap_text.Rd
+++ b/man/wrap_text.Rd
@@ -7,13 +7,14 @@
 wrap_text(x, width = 80L, ignore_newlines = TRUE)
 }
 \arguments{
-\item{x}{Character vector to be wrapped.}
+\item{x}{\link[checkinput:all_characters]{character vector} to be wrapped.}
 
-\item{width}{A positive number giving the maximum line width (in characters)
+\item{width}{\link[checkinput:is_natural]{natural number} giving the maximum
+line width (in characters)
 after wrapping. Can be \code{Inf} to not wrap text.}
 
 \item{ignore_newlines}{\code{TRUE} or \code{FALSE}: should newlines in \code{x} be replaced
-by a blank character?}
+by blank characters?}
 }
 \value{
 A string containing \code{x} wrapped to a maximum of \code{width} characters, with
@@ -25,6 +26,8 @@ characters longer than \code{width} occurs without a blank character to wrap at.
 Wrap text at blank characters to achieve a maximum line width.
 }
 \details{
+\code{character(0)} input to \code{x} is returned unchanged, with a warning.
+
 \code{x} of length larger than one is pasted into a single string, separating the
 parts by blank characters.
 


### PR DESCRIPTION
### Breaking changes
- `not_in()`: allow zero-length input in `x` and `table`, returning `logical(0)` for zero-length input that is absent from `table` if `value` is `FALSE`.
- `vect_to_char()`: report the `type` instead of the `class` for zero-length input and `NA`s. Not round integer values. Add examples on handling zero-length input.
- `wrap_text()`: allow `character(0)` as input to `x`, returning it unchanged, with a warning. `width` now has to be a natural number.

### Minor updates
- `get_file_path()`: use `fs::dir_ls()` instead of `list.files()` to more easily list only files.