### PR TITLE
progutils 0.12.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: progutils
 Title: Programming Utilities
-Version: 0.11.0
+Version: 0.12.0
 Authors@R: 
     person("Jesse", "Alderliesten", , "jessealderliesten@hotmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-1132-4310"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,12 +11,11 @@ URL: https://github.com/JesseAlderliesten/progutils,
 BugReports: https://github.com/JesseAlderliesten/progutils/issues
 Imports: 
     checkinput (>= 1.0.0),
-    fs,
+    fs (>= 1.3.0),
     utils
 Suggests:
     stats,
-    tinytest (>= 1.4.1),
-    tools
+    tinytest (>= 1.4.1)
 Remotes: 
     github::JesseAlderliesten/checkinput
 Config/roxygen2/version: 8.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# progutils devel
+# progutils 0.12.0
 
 ### Breaking changes
 - `create_tempdir()`: rename argument `pattern` to `prefix`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# progutils devel
+
+### Breaking changes
+- `create_tempdir()`: rename argument `pattern` to `prefix`.
+- Dependency `fs`: require minimum version of `1.3.0` to use argument `recurse`.
+- Remove suggested dependency `tools` that has been obsolete since replacing
+  `file_path_no_ext()` by `fs::path_ext_remove()` and `file_path_ext()` by
+  `fs::path_ext()` in `progutils 0.3.0`.
+
+
 # progutils 0.11.0
 
 ### Breaking changes

--- a/R/are_equal.R
+++ b/R/are_equal.R
@@ -1,4 +1,4 @@
-#' Are numeric values nearly equal
+#' Check that numeric values are nearly equal
 #'
 #' Test element-wise near-equality of numeric vectors by allowing for small
 #' numeric errors to make `are_equal()` safer than [`==`][Comparison].
@@ -24,9 +24,9 @@
 #' @seealso
 #' [checkinput::is_natural()] to check for element-wise near-equality to natural
 #' numbers; [all.equal()] to check more generally for near-equality;
-#' [identical()] to check for exact equality and [`Comparison`] to do so using
-#' binary operators;
-#' [match()] and `progutils::not_in()` to compare character vectors;
+#' [identical()], [not_in()] and [match()] (containing `%in%` and, from \R
+#' `4.6.0` onwards, `'%notin%'`) to check for exact (in)equality, with
+#' [`Comparison`] to do so using binary operators;
 #' [\R FAQ 7.31](
 #' https://CRAN.R-project.org/doc/manuals/R-FAQ.html#Why-doesn_0027t-R-think-these-numbers-are-equal_003f)
 #' for background on numerical equality;

--- a/R/check_case.R
+++ b/R/check_case.R
@@ -8,9 +8,10 @@
 #' [signal][signal_text()] as indicated by argument `signal`.
 #'
 #' @returns
-#' Character vector with [unique][unique()], [sorted][sort()] values in `x` that
-#' only differ from each other in their case, or `character(0)` if no such
-#' values are present. The return is [invisible].
+#' A [character vector][checkinput::all_characters()] with [unique][unique()],
+#' [sorted][sort()] values in `x` that only differ from each other in their
+#' case, or `character(0)` if no such values are present, returned
+#' [invisibly][invisible].
 #'
 #' @section Notes:
 #' The sorting order in the result depends on the used [locale][locales] (see

--- a/R/create_dir.R
+++ b/R/create_dir.R
@@ -12,11 +12,10 @@
 #' current date in the [format][strftime()] `YYYY_mm_dd`?
 #'
 #' @details
-#' The [absolute normalised][fs::path_abs()] path is returned such that the
+#' The [absolute, normalised][fs::path_abs()] path is returned such that the
 #' returned path still works if the [working directory][getwd()] changes. On
-#' case-insensitive file systems (e.g., Windows and macOS), normalization
-#' adjusts the case to match case-insensitive names of directories that are
-#' already present (see the `Examples`).
+#' case-insensitive file systems, normalization also adjusts the case to match
+#' names of directories that are already present (see the `Examples`).
 #'
 #' @returns
 #' A character string with the [absolute normalized][fs::path_abs()] path to the
@@ -25,20 +24,17 @@
 #' an existing file instead of to an directory.
 #'
 #' @section Side effects:
-#' The directory indicated by the returned path is [created][create_dir()] if it
-#' does not yet exist.
+#' The directory indicated by the returned path is [created][fs::dir_create()]
+#' if it does not yet exist.
 #'
 #' @seealso
-#' [checkinput::is_path()] to check if a path is valid, and the `Note on paths`
-#' in its documentation;
+#' [checkinput::is_path()] to check if a path is valid, with a `Note on paths`
+#' and extensive references about file paths and directories;
+#' [create_tempdir()] for a safe way to create temporary directories;
 #' [create_file_path()] to create a file path and creating the indicated
 #' directory if it does not yet exist;
-#' [create_tempdir()] for a safe way to create temporary directories;
-#' [checkinput::is_path()] and references there about file paths and directories;
-#' [fs::dir_exists()] and [fs::dir_create()] used by this function (and the
-#' base-equivalent [dir.create()] of the latter);
-#' [get_file_path()] to check if a file exists and is a unique match to a
-#' pattern.
+#' [fs::dir_exists()] and [fs::dir_create()] (with its base-equivalent
+#' [dir.create()]) used by this function;
 #'
 #' @family functions to handle paths and directories
 #'

--- a/R/create_dir.R
+++ b/R/create_dir.R
@@ -40,7 +40,7 @@
 #'
 #' @examples
 #' # Use a temporary subdirectory to not write in the user's directory
-#' my_tempdir <- create_tempdir(pattern = "examplecreatedir")
+#' my_tempdir <- create_tempdir(prefix = "examplecreatedir")
 #'
 #' # Create directory 'dir_one' inside this temporary directory
 #' res_dir_one <- create_dir(dir = fs::path(my_tempdir, "dir_one"),

--- a/R/create_file_path.R
+++ b/R/create_file_path.R
@@ -7,14 +7,16 @@
 #' name, including the file
 #' extension like `.csv` or `.txt`. Should adhere to the restrictions described
 #' in [checkinput::is_path()].
-#' @param format_stamp A character string indicating the [format][strftime()] of
+#' @param format_stamp [character string][checkinput::is_character()] indicating
+#' the [format][strftime()] of
 #' the stamp to be added in front of the file name. No stamp is added if
 #' `format_stamp` is an empty string (i.e., `""`). The formatted stamp is
 #' treated as part of the filename, such that the same restrictions apply, see
 #' `Details`.
 #'
 #' @returns
-#' The created file path, returned [invisibly][invisible()].
+#' The created [absolute normalized][fs::path_abs()] file path, returned
+#' [invisibly][invisible()].
 #'
 #' @details
 #' `filename` **should** contain a file extension (i.e., a dot followed by any
@@ -29,17 +31,14 @@
 #' as part of `format_stamp` to create precise stamps by truncating seconds to
 #' `0 <= n <= 6` decimal places, see [strftime()] for details.
 #'
-#' @section Side effects:
-#' The directory indicated by the returned file path is [created][create_dir()]
-#' if it does not yet exist.
+#' @inheritSection create_dir Side effects
 #'
 #' @seealso
-#' [checkinput::is_path()] to check if a path is valid, and the `Note on paths`
-#' in its documentation;
+#' [checkinput::is_path()] to check if a path is valid, with a `Note on paths`
+#' and extensive references about file paths and directories;
 #' [get_file_path()] to check if a file exists and is a unique match to a pattern;
-#' [fs::path()] to construct file paths in a platform-independent way;
-#' [fs::path_abs()] to create absolute normalised paths;
-#' [create_dir()] to create a directory if it does not yet exist
+#' [create_dir()] (used by this function) to create a directory if it does not
+#' yet exist
 #'
 #' @family functions to handle paths and directories
 #'
@@ -70,7 +69,7 @@
 #'
 #' @export
 create_file_path <- function(filename, format_stamp = "%Y_%m_%d_%H_%M_%S",
-                             dir = fs::path_wd("output"), add_date = TRUE) {
+                             dir = fs::path(".", "output"), add_date = TRUE) {
   filename_label <- deparse1(substitute(filename))
 
   stopifnot(checkinput::is_character(filename),

--- a/R/create_file_path.R
+++ b/R/create_file_path.R
@@ -44,7 +44,7 @@
 #'
 #' @examples
 #' # Use a temporary directory to not write in the user's directory
-#' my_tempdir <- create_tempdir(pattern = "examplecreatefilepath")
+#' my_tempdir <- create_tempdir(prefix = "examplecreatefilepath")
 #'
 #' (create_file_path(filename = "abc.txt", format_stamp = "",
 #'                   dir = my_tempdir, add_date = TRUE))

--- a/R/create_tempdir.R
+++ b/R/create_tempdir.R
@@ -1,14 +1,14 @@
-#' Create a new temporary directory
+#' Create a temporary directory
 #'
-#' Create a new temporary directory that can safely be removed.
+#' Create a temporary directory that can safely be removed.
 #'
-#' @param pattern [character string][checkinput::is_character()] with the
+#' @param prefix [character string][checkinput::is_character()] with the
 #' initial part of the name of the new temporary directory, only containing
 #' characters that are valid in a [path][checkinput::is_path()].
 #'
 #' @details
 #' The new directory is [created][dir.create()] inside [tempdir()]. Its
-#' [name][tempfile()] starts with the string given by `pattern` and is followed
+#' [name][tempfile()] starts with the string given by `prefix` and is followed
 #' by a random string in hex. This random string **might** contain a dot (`.`)
 #' such that the directory might appear to have a file extension, see the
 #' section `Source` in `help("tempdir")`. An error is thrown if creating the
@@ -31,9 +31,7 @@
 #' The [absolute normalized][fs::path_abs()] path to the created temporary
 #' directory, returned [invisibly][invisible].
 #'
-#' @section Side effects:
-#' The temporary directory indicated by the returned path is
-#' [created][fs::dir_create()] inside [tempdir()].
+#' @inheritSection create_dir Side effects
 #'
 #' @section Usage in practice:
 #' `Examples` and `tests` should write to a temporary directory that is cleaned
@@ -41,7 +39,7 @@
 #' will issue a `Note` about [`detritus in the temp directory`](
 #' https://contributor.r-project.org/cran-cookbook/code_issues.html#leaving-files-in-the-temporary-directory)
 #' and CRAN will not accept your package, see section `Source packages` from the
-#' [CRAN policies](https://cran.r-project.org/web/packages/policies.html).
+#' [CRAN policies](https://cran.r-project.org/web/packages/policies.html)).
 #' Although [tempdir()] points to a temporary
 #' directory, that directory should **not** be removed because other processes
 #' in \R and [RStudio](https://posit.co/products/open-source/rstudio) also use
@@ -49,7 +47,7 @@
 #' clean up by [removing][unlink()] that subdirectory:
 #'
 #' ```
-#' my_tempdir <- create_tempdir(pattern = "subtempdir")
+#' my_tempdir <- create_tempdir(prefix = "subtempdir")
 #' < do stuff >
 #' unlink(my_tempdir, recursive = TRUE)
 #' ```
@@ -62,46 +60,46 @@
 #' @inheritSection checkinput::is_path Programming notes
 #'
 #' @seealso
-#' [tempfile()] used in this function to create the paths for the temporary
-#' directory;
+#' [checkinput::is_path()] to check if a path is valid, with a `Note on paths`
+#' and extensive references about file paths and directories;
+#' [create_dir()] to create a (non-temporary) directory if it does not yet exist;
 #' [local()] and
 #' [withr::local_tempdir()](https://withr.r-lib.org/reference/with_tempfile.html)
 #' for automated deletion of temporary directories;
-#' [create_dir()] to create (non-temporary) directories;
-#' [checkinput::is_path()] to check if a path is valid, with the `Note on paths`
-#' in its documentation.
+#' [tempfile()] used in this function to create the paths for the temporary
+#' directory;
 #'
 #' @family functions to handle paths and directories
 #'
 #' @examples
 #' tempdir(check = TRUE)
 #' # Create a directory inside the directory returned by 'tempdir()'
-#' (my_subtempdir_ex1 <- create_tempdir(pattern = "subtempdir"))
+#' (my_subtempdir_ex1 <- create_tempdir(prefix = "subtempdir"))
 #'
-#' # Using the same 'pattern' again creates another directory
-#' (my_subtempdir_ex2 <- create_tempdir(pattern = "subtempdir"))
+#' # Using the same 'prefix' again creates another directory
+#' (my_subtempdir_ex2 <- create_tempdir(prefix = "subtempdir"))
 #'
 #' # It is not possible to create recursive subdirectories
-#' try(no_subtempdir <- create_tempdir(pattern = "subtempdir/otherdir"))
-#' try(no_subtempdir <- create_tempdir(pattern = "subtempdir\\otherdir"))
+#' try(no_subtempdir <- create_tempdir(prefix = "subtempdir/otherdir"))
+#' try(no_subtempdir <- create_tempdir(prefix = "subtempdir\\otherdir"))
 #'
 #' # Clean up
 #' unlink(c(my_subtempdir_ex1, my_subtempdir_ex2), recursive = TRUE)
 #' rm(my_subtempdir_ex1, my_subtempdir_ex2)
 #'
 #' @export
-create_tempdir <- function(pattern = "tempdir") {
+create_tempdir <- function(prefix = "tempdir") {
   stopifnot(
-    "'pattern' should be a non-empty, non-NA_character_ character string" =
-      checkinput::is_character(pattern),
-    # Using 'pattern == basename(pattern)' to detect slashes does not work on
+    "'prefix' should be a non-empty, non-NA_character_ character string" =
+      checkinput::is_character(prefix),
+    # Using 'prefix == basename(prefix)' to detect slashes does not work on
     # Ubuntu and MacOS
-    "'pattern' should not include file separators" =
-      !grepl(pattern = "\\", x = pattern, fixed = TRUE) &&
-      !grepl(pattern = "/", x = pattern, fixed = TRUE))
+    "'prefix' should not include file separators" =
+      !grepl(pattern = "\\", x = prefix, fixed = TRUE) &&
+      !grepl(pattern = "/", x = prefix, fixed = TRUE))
 
   # Inspired by withr::local_tempdir()
-  tempdir_target <- tempfile(pattern = pattern, tmpdir = tempdir(check = TRUE))
+  tempdir_target <- tempfile(pattern = prefix, tmpdir = tempdir(check = TRUE))
   stopifnot(checkinput::is_path(tempdir_target))
   tempdir_target <- as.character(fs::path_abs(path = tempdir_target))
 
@@ -111,7 +109,7 @@ create_tempdir <- function(pattern = "tempdir") {
     # This error should not occur if 'tempfile()' worked correctly when creating
     # 'tempdir_target' but makes it possible to detect problems that might arise.
     stop("Temporary directory already exists (possibly as a file): change",
-         " 'pattern' (", paste_quoted(pattern), "):\n", tempdir_target)
+         " 'prefix' (", paste_quoted(prefix), "):\n", tempdir_target)
   }
 
   # Notes:

--- a/R/get_file_path.R
+++ b/R/get_file_path.R
@@ -8,7 +8,8 @@
 #' @param pattern [character string][checkinput::is_character()] containing a
 #' [regular expression][base::regex]
 #' used to select names of files that are present in `dir`.
-#' @param ignore_case `TRUE` or `FALSE`: use case-insensitive pattern matching?
+#' @param ignore_case `TRUE` or `FALSE`: use [case-insensitive][tolower()]
+#' pattern matching?
 #' @param quietly `TRUE` or `FALSE`: suppress the message with the found file
 #' name?
 #'
@@ -19,7 +20,8 @@
 #' message indicates if any case-insensitive match is present.
 #'
 #' In contrast to the default of [list.files()], `get_file_path()` also finds
-#' 'hidden' files, i.e., files with names that start with a dot.
+#' 'hidden' files, i.e., files with names that start with a dot, and excludes
+#' directories.
 #'
 #' Paths will be [normalized][fs::path_abs()] to ensure they still work if the
 #' [working directory][getwd()] changes.
@@ -31,16 +33,15 @@
 #' to obtain the filename itself.
 #'
 #' @seealso
-#' [checkinput::is_path()] to check if a path is valid, and the `Note on paths`
-#' in its documentation;
-#' [create_dir()] to create a directory if does not yet exist;
+#' [checkinput::is_path()] to check if a path is valid, with a `Note on paths`
+#' and extensive references about file paths and directories;
+#' [create_file_path()] to create a file path and creating the indicated
+#' directory if it does not yet exist;
 #' [fs::file_exists()] and [list.files()] (which **includes** directories) to
 #' check for existence of files without checking they are a unique match to a
 #' pattern;
 #' [file.info()] and [file.access()] to extract information about files or
-#' directories;
-#' [fs::path()] to construct file paths in a platform-independent way;
-#' [fs::path_abs()] to create absolute paths.
+#' directories
 #'
 #' @family functions to handle paths and directories
 #' @family functions to check equality

--- a/R/get_file_path.R
+++ b/R/get_file_path.R
@@ -48,7 +48,7 @@
 #'
 #' @examples
 #' # Create files in a temporary directory so we know what is present.
-#' my_tempdir <- create_tempdir(pattern = "examplegetfilepath")
+#' my_tempdir <- create_tempdir(prefix = "examplegetfilepath")
 #' my_tempfiles <- fs::path_abs(
 #'   fs::path(my_tempdir, paste0(c("some_filename", "another_filename"), ".txt"))
 #' )

--- a/R/not_in.R
+++ b/R/not_in.R
@@ -1,4 +1,4 @@
-#' Are values absent
+#' Check that values are absent
 #'
 #' Check that values from one vector are absent from another vector
 #'
@@ -49,8 +49,9 @@
 #' @seealso
 #' [setdiff()] for a similar function which removes duplicates;
 #' [are_equal()] to match numeric input using a tolerance;
-#' [match()] containing `%in%`, and, from \R `4.6.0` onwards, `'%notin%'`, on
-#' which this function is based.
+#' [identical()], [not_in()] and [match()] (containing `%in%` and, from \R
+#' `4.6.0` onwards, `'%notin%'`) to check for exact (in)equality, with
+#' [`Comparison`] to do so using binary operators
 #'
 #' @family functions to check equality
 #'

--- a/R/reorder_cols.R
+++ b/R/reorder_cols.R
@@ -3,7 +3,7 @@
 #' @param x Object with at least one column. Columns should have unique,
 #' syntactically valid names, see [checkinput::all_names()].
 #' @param new_order Character vector with a length larger than zero containing
-#' unique names in the new order of the columns.
+#' unique names in the new order.
 #'
 #' @details
 #' Column names of `x` that are missing from `new_order` are appended to
@@ -16,7 +16,9 @@
 #' `x` with reordered columns.
 #'
 #' @seealso
-#' [order()], [sort()]
+#' [order()]; [sort()];
+#' [append()] which, despite its name, can insert values into a vector at any
+#' place
 #'
 #' @family functions to modify sorting order
 #'

--- a/R/reorder_levels.R
+++ b/R/reorder_levels.R
@@ -1,10 +1,9 @@
 #' Reorder factor levels
 #'
+#' @inheritParams reorder_cols new_order
 #' @param x Factor with levels to be reordered to `new_order`, or character
 #' vector to be converted to a factor with levels ordered as `new_order`. Should
 #' have length larger than zero.
-#' @param new_order Unique character vector with a length larger than zero
-#' indicating the new order of the factor levels.
 #' @param warn_drop_order `TRUE` or `FALSE`: warn if values of `new_order` are
 #' dropped because they are not present in `x`?
 #'
@@ -25,8 +24,8 @@
 #' warning if `warn_drop_order` is `TRUE`.
 #'
 #' @returns
-#' `x` after converting it to a [factor] with its levels reordered to
-#' `new_order`, dropping values in `new_order` not present in `x`.
+#' `x` after converting it to a [factor] with levels reordered to
+#' `new_order`, dropping values in `new_order` that are not present in `x`.
 #'
 #' @section Notes:
 #' Reordering levels of factor `f` by replacing levels through code like
@@ -34,7 +33,8 @@
 #' `Example`.
 #'
 #' @seealso
-#' [stats::relevel()] to assign one reference level to a factor
+#' [stats::relevel()] to assign one reference level to a factor;
+#' [order()]; [sort()]
 #'
 #' @family functions to convert types
 #' @family functions to modify factors

--- a/R/replace_vals.R
+++ b/R/replace_vals.R
@@ -1,15 +1,18 @@
-#' Replace character values or factor levels
+#' Replace values
+#'
+#' Replace values, also handling factor levels
 #'
 #' @param x [Character][character] vector with values to be replaced, or
 #' [factor] with [levels] to be replaced.
 #' @param old Character vector with values to be replaced. Should be [unique]
 #' and not contain the value `new`, otherwise an error is thrown.
-#' @param new Character string of length one with the new value.
-#' @param ignore_case `TRUE` or `FALSE`: ignore [case][tolower] when looking for
+#' @param new Character string with the new value.
+#' @param ignore_case `TRUE` or `FALSE`: ignore [case][tolower()] when looking for
 #' `old`? See `Details`.
 #' @param allow_multiple `TRUE` or `FALSE`: allow multiple values of `old` to
 #' match `x`? See `Details`.
-#' @param warn_absent `TRUE` or `FALSE`: warn if `old` nor `new` are found in
+#' @param warn_absent `TRUE` or `FALSE`: warn if neither `old` nor `new` is
+#' found in
 #' `x`? It is silently assumed replacement is not necessary anymore if `new` is
 #' found.
 #' @param signal_case_old,signal_case_new `"error"`, `"warning"`, `"message"`,
@@ -20,8 +23,8 @@
 #' @param signal_old_ignore_case `TRUE` or `FALSE`: use `signal_case_old` if
 #' `ignore_case` is `TRUE`? If `FALSE`, no signal is emitted if `ignore_case` is
 #' `TRUE`.
-#' @param quiet `TRUE` or `FALSE`: suppress printing the message with the values
-#' that have been replaced?
+#' @param quiet `TRUE` or `FALSE`: suppress the message indicating which values
+#' have been replaced?
 #'
 #' @details
 #' Values in `x` that [only differ][check_case()] from `new` in their case are

--- a/R/signal_text.R
+++ b/R/signal_text.R
@@ -2,7 +2,8 @@
 #'
 #' Signal a text to the user through an error, warning, or message.
 #'
-#' @param text Vector with text to be signalled, coerced to character by
+#' @param text [character vector][checkinput::all_characters()] with text to be
+#' signalled, coerced to a [character string][checkinput::is_character()] by
 #' [vect_to_char()].
 #' @param signal [character string][checkinput::is_character()] indicating the
 #' type of signal to be used:
@@ -23,13 +24,11 @@
 #' attribute to the returned object, see the last `Example`.
 #'
 #' @returns
-#' `text`, with a phrase indicating the origin of the signal if `origin` is not
-#' `NULL`, returned [invisibly][invisible()].
+#' [character string][checkinput::is_character()] containing `text`, with a
+#' phrase indicating the origin of the signal if `origin` is not `NULL`,
+#' returned [invisibly][invisible()].
 #'
 #' @family functions to modify character vectors
-#'
-#' @seealso
-#' [wrap_text()]
 #'
 #' @examples
 #' test_text <- c("Some text", "Some other text")

--- a/R/unpaste_unquote.R
+++ b/R/unpaste_unquote.R
@@ -1,12 +1,13 @@
 #' Create a character vector from a string with quotation marks
 #'
 #' @param x a [character string][checkinput::is_character()].
-#' @param collapse [character string][checkinput::all_characters()] with
+#' @param collapse [character vector][checkinput::all_characters()] with
 #' elements that were used to collapse
 #' values when `x` was created, and are now used to [split][strsplit()] `x` on.
 #' Can be `character(0)` to leave `x` as a character string.
-#' @param quotemarks Character vector with quotation marks to be removed from
-#' `x`. Can be `character(0)` to not remove any quotation marks.
+#' @param quotemarks [character vector][checkinput::all_characters()] with
+#' quotation marks to be removed from `x`. Can be `character(0)` to not remove
+#' any quotation marks.
 #'
 #' @details
 #' `unpaste_unquote()` is **not** the exact reverse of [paste_quoted()]: it does
@@ -14,8 +15,8 @@
 #' to `NULL`, or `"'character(0)'"` to `character(0)`.
 #'
 #' @returns
-#' `x` without the quotation marks indicated by `quotemarks`, split into a
-#' vector on `collapse`.
+#' `x` without the quotation marks in `quotemarks`, split into a vector on the
+#' string in `collapse`.
 #'
 #' @seealso
 #' [paste_quoted()] for the approximate opposite of `unpaste_unquote()`.

--- a/R/vect_to_char.R
+++ b/R/vect_to_char.R
@@ -33,11 +33,11 @@
 #' values of numeric `x` rounded to `signif`
 #' [significant][signif()] digits, wrapped to `width` characters.
 #'
-#' If `collapse` is `NULL`, a [character **vector**][checkinput::all_characters()]
+#' If `collapse` is `NULL`, a [character vector][checkinput::all_characters()]
 #' with the same elements as `x`
 #' is returned, wrapping on a per-element basis. If `collapse` is not `NULL`,
 #' the name-value pairs are separated by `collapse`, thus returning a
-#' [character **string**][checkinput::is_character()].
+#' [character string][checkinput::is_character()].
 #'
 #' See `Details` on handling of some special values.
 #'

--- a/R/vect_to_char.R
+++ b/R/vect_to_char.R
@@ -29,13 +29,15 @@
 #'   converts factors to characters).
 #'
 #' @returns
-#' The names and values in `x`, with values of numeric `x` rounded to `signif`
+#' A character vector or character string with the names and values in `x`, with
+#' values of numeric `x` rounded to `signif`
 #' [significant][signif()] digits, wrapped to `width` characters.
 #'
-#' If `collapse` is `NULL`, a character **vector** with the same elements as `x`
+#' If `collapse` is `NULL`, a [character **vector**][checkinput::all_characters()]
+#' with the same elements as `x`
 #' is returned, wrapping on a per-element basis. If `collapse` is not `NULL`,
-#' the name-value pairs are separated by `collapse`, thus returning a character
-#' **string**.
+#' the name-value pairs are separated by `collapse`, thus returning a
+#' [character **string**][checkinput::is_character()].
 #'
 #' See `Details` on handling of some special values.
 #'
@@ -45,7 +47,8 @@
 #' see the last `Example`.
 #'
 #' @seealso
-#' [toString()] which can be used if names of `x` can be removed;
+#' [toString()] which is shorthand for `paste(x, collapse = ", ")` and can be
+#' used instead of `vect_to_char()` if names of `x` can be removed;
 #' `vignette("type_coercion", package = "checkinput")` and
 #' `help("is_zerolength", package = "checkinput")` for a discussion of some
 #' issues with type conversion and zero-length input when [combining][c()]

--- a/R/wrap_text.R
+++ b/R/wrap_text.R
@@ -23,7 +23,8 @@
 #' `ignore_newlines` is `TRUE` and are retained if `ignore_newlines` is `FALSE`.
 #'
 #' @returns
-#' A string containing `x` wrapped to a maximum of `width` characters, with
+#' A [character string][checkinput::is_character()] containing `x` wrapped to a
+#' maximum of `width` characters, with
 #' newlines inserted at blank characters. A warning is issued if the width of a
 #' fragment in the output exceeds `width`: this occurs if a stretch of
 #' characters longer than `width` occurs without a blank character to wrap at.
@@ -32,6 +33,12 @@
 #' The call `wrap_text(x, width)` can be replaced by
 #' `paste0(strwrap(x, width + 1L), collapse = "\n")` if `x` has length one and
 #' `ignore_newlines` is `TRUE`.
+#'
+#' Using `wrap_text()` on `x` of variable length, e.g., in the text of warnings
+#' that report a file path or a user-provided variable name, makes the location
+#' of newlines unpredictable and thus difficult to test reliably. To circumvent
+#' this, put the constant part in the front of the message and hardcode newlines
+#' using `\n`.
 #'
 #' @section Notes:
 #' The output is printed as a string with newlines represented as `\n`. Use
@@ -42,14 +49,8 @@
 #' contrast, argument `width` in [strwrap()] indicates the width **at** which
 #' text should be wrapped.
 #'
-#' @section Programming notes:
-#' Using `wrap_text()` on `x` of variable length, e.g., in the text of warnings
-#' that report a file path or a user-provided variable name, makes the location
-#' of newlines unpredictable and thus difficult to test reliably. To circumvent
-#' this, put the constant part in the front of the message and hardcode newlines
-#' using `\n`.
-#'
-#' @seealso [cat()] [paste()] [strwrap()]
+#' @seealso
+#' [cat()]; [paste()]; [strwrap()]
 #'
 #' @family functions to modify character vectors
 #'

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ License](LICENSE.md).
     To cite package 'progutils' in publications use:
 
       Alderliesten J (2026). _progutils: Programming Utilities_. R package
-      version 0.11.0, <https://github.com/JesseAlderliesten/progutils>.
+      version 0.12.0, <https://github.com/JesseAlderliesten/progutils>.
 
     A BibTeX entry for LaTeX users is
 
@@ -115,7 +115,7 @@ License](LICENSE.md).
         title = {progutils: Programming Utilities},
         author = {Jesse Alderliesten},
         year = {2026},
-        note = {R package version 0.11.0},
+        note = {R package version 0.12.0},
         url = {https://github.com/JesseAlderliesten/progutils},
       }
 

--- a/inst/tinytest/test_create_dir.R
+++ b/inst/tinytest/test_create_dir.R
@@ -2,7 +2,7 @@ tinytest::report_side_effects()
 
 
 #### Test the examples ####
-my_tempdir <- create_tempdir(pattern = "testexamplecreatedir")
+my_tempdir <- create_tempdir(prefix = "testexamplecreatedir")
 basename_my_tempdir <- basename(my_tempdir)
 
 res_dir_one <- create_dir(dir = fs::path(my_tempdir, "dir_one"),
@@ -49,7 +49,7 @@ rm(my_tempdir, res_dir_one, res_dir_one_v2, res_dir_ONE, res_dir_date,
 
 
 #### Tests ####
-my_tempdir <- create_tempdir(pattern = "testcreatedir")
+my_tempdir <- create_tempdir(prefix = "testcreatedir")
 basename_my_tempdir <- basename(my_tempdir)
 pattern_temp <- fs::path(basename_my_tempdir, "temp")
 

--- a/inst/tinytest/test_create_file_path.R
+++ b/inst/tinytest/test_create_file_path.R
@@ -3,7 +3,7 @@ tinytest::report_side_effects()
 #### Tests ####
 ##### Preparations #####
 # Create temporary directory and temporary file to use in tests.
-my_tempdir <- create_tempdir(pattern = "testcreatepath")
+my_tempdir <- create_tempdir(prefix = "testcreatepath")
 basename_my_tempdir <- basename(my_tempdir)
 
 pattern_temp <- paste0(basename_my_tempdir, ".+$")

--- a/inst/tinytest/test_create_tempdir.R
+++ b/inst/tinytest/test_create_tempdir.R
@@ -2,13 +2,13 @@ tinytest::report_side_effects()
 
 #### Test the examples ####
 basename_my_tempdir <- basename(tempdir(check = TRUE))
-pattern <- "subtempdir"
+prefix <- "subtempdir"
 
 # Create a directory inside the directory returned by 'tempdir()'
-my_subtempdir_ex1 <- create_tempdir(pattern = pattern)
+my_subtempdir_ex1 <- create_tempdir(prefix = prefix)
 
-# Using the same 'pattern' again creates another directory
-my_subtempdir_ex2 <- create_tempdir(pattern = pattern)
+# Using the same 'prefix' again creates another directory
+my_subtempdir_ex2 <- create_tempdir(prefix = prefix)
 
 # Test that directories exist
 expect_true(fs::dir_exists(my_subtempdir_ex1))
@@ -18,25 +18,25 @@ expect_true(fs::dir_exists(my_subtempdir_ex2))
 expect_identical(basename(dirname(my_subtempdir_ex1)), basename_my_tempdir)
 expect_identical(basename(dirname(my_subtempdir_ex2)), basename_my_tempdir)
 
-# Test that names start with 'pattern'
-expect_true(startsWith(x = basename(my_subtempdir_ex1), prefix = pattern))
-expect_true(startsWith(x = basename(my_subtempdir_ex2), prefix = pattern))
+# Test that names start with 'prefix'
+expect_true(startsWith(x = basename(my_subtempdir_ex1), prefix = prefix))
+expect_true(startsWith(x = basename(my_subtempdir_ex2), prefix = prefix))
 
-# Test that names are not equal to 'pattern'
-expect_true(basename(my_subtempdir_ex1) != pattern)
-expect_true(basename(my_subtempdir_ex2) != pattern)
+# Test that names are not equal to 'prefix'
+expect_true(basename(my_subtempdir_ex1) != prefix)
+expect_true(basename(my_subtempdir_ex2) != prefix)
 
 # Test that names are not the same
 expect_true(my_subtempdir_ex1 != my_subtempdir_ex2)
 
 # Test that it is not possible to create recursive directories
 expect_error(
-  create_tempdir(pattern = "subtempdir/otherdir"),
-  pattern = "'pattern' should not include file separators", fixed = TRUE)
+  create_tempdir(prefix = "subtempdir/otherdir"),
+  pattern = "'prefix' should not include file separators", fixed = TRUE)
 
 expect_error(
-  create_tempdir(pattern = "subtempdir\\otherdir"),
-  pattern = "'pattern' should not include file separators", fixed = TRUE)
+  create_tempdir(prefix = "subtempdir\\otherdir"),
+  pattern = "'prefix' should not include file separators", fixed = TRUE)
 
 #### Delete the created temporary files ####
 unlink(c(my_subtempdir_ex1, my_subtempdir_ex2), recursive = TRUE)
@@ -44,14 +44,14 @@ expect_false(fs::dir_exists(my_subtempdir_ex1))
 expect_false(fs::dir_exists(my_subtempdir_ex2))
 
 #### Remove objects used in tests ####
-rm(my_subtempdir_ex1, my_subtempdir_ex2, basename_my_tempdir, pattern)
+rm(my_subtempdir_ex1, my_subtempdir_ex2, basename_my_tempdir, prefix)
 
 
 #### Tests ####
-pattern <- "subtempdir"
+prefix <- "subtempdir"
 my_subtempdir_t1 <- create_tempdir()
 my_tempfile <- fs::path(my_subtempdir_t1, "test_df.csv")
-my_subtempdir_t2 <- create_tempdir(pattern = ".")
+my_subtempdir_t2 <- create_tempdir(prefix = ".")
 
 # Test that temporary subdirectory is writeable by writing a csv-file, modified
 # from an example in help(write.table)
@@ -59,34 +59,34 @@ expect_false(fs::is_file(my_tempfile))
 write.table(x = data.frame(a = "a", b = pi), file = my_tempfile)
 expect_true(fs::is_file(my_tempfile))
 
-# Test that pattern '"."' is accepted
+# Test that prefix '"."' is accepted
 expect_true(fs::dir_exists(my_subtempdir_t2))
 
 #### Delete the created temporary files ####
 unlink(c(my_subtempdir_t1, my_subtempdir_t2), recursive = TRUE)
 
 #### Remove objects used in tests ####
-rm(my_tempfile, pattern, my_subtempdir_t1, my_subtempdir_t2)
+rm(my_tempfile, prefix, my_subtempdir_t1, my_subtempdir_t2)
 
 
 #### Invalid input ####
-for(pattern in list(3, NULL, character(0), "", c("temp_p1", "temp_p2"))) {
+for(prefix in list(3, NULL, character(0), "", c("temp_p1", "temp_p2"))) {
     expect_error(
-      create_tempdir(pattern = pattern),
-      pattern = "'pattern' should be a non-empty, non-NA_character_ character string",
+      create_tempdir(prefix = prefix),
+      pattern = "'prefix' should be a non-empty, non-NA_character_ character string",
       fixed = TRUE)
 }
 
-for(pattern in c("tem\\p_p1", "temp_p2\\", "tem/p_p3", "temp_p4/", "\\temp_p5",
+for(prefix in c("tem\\p_p1", "temp_p2\\", "tem/p_p3", "temp_p4/", "\\temp_p5",
                  "/temp_p6")) {
   expect_error(
-    create_tempdir(pattern = pattern),
-    pattern = "'pattern' should not include file separators", fixed = TRUE)
+    create_tempdir(prefix = prefix),
+    pattern = "'prefix' should not include file separators", fixed = TRUE)
 }
 
 expect_warning(
   expect_error(
-    create_tempdir(pattern = "abc|def"),
+    create_tempdir(prefix = "abc|def"),
     pattern = "checkinput::is_path(tempdir_target) is not TRUE",
     fixed = TRUE),
   pattern = "'tempdir_target' should not contain '\"', '*', '?', '|', '<' or '>'",
@@ -94,4 +94,4 @@ expect_warning(
 
 
 #### Remove objects used in tests ####
-rm(pattern)
+rm(prefix)

--- a/inst/tinytest/test_get_file_path.R
+++ b/inst/tinytest/test_get_file_path.R
@@ -2,7 +2,7 @@ tinytest::report_side_effects()
 
 
 #### Test the examples ####
-my_tempdir <- create_tempdir(pattern = "testexamplegetfilepath")
+my_tempdir <- create_tempdir(prefix = "testexamplegetfilepath")
 my_tempfiles <- fs::path_abs(
   fs::path(my_tempdir, paste0(c("some_filename", "another_filename"), ".txt"))
 )
@@ -66,7 +66,7 @@ rm(my_tempdir, my_tempfiles)
 
 #### Tests ####
 # Create files in a temporary directory so we know what is present.
-my_tempdir <- create_tempdir(pattern = "testgetfilepath")
+my_tempdir <- create_tempdir(prefix = "testgetfilepath")
 fs::dir_create(path = fs::path(my_tempdir, "test_dir", "abc"))
 
 # Test that temporary subdirectory is writeable by writing a csv-file, modified

--- a/man/are_equal.Rd
+++ b/man/are_equal.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/are_equal.R
 \name{are_equal}
 \alias{are_equal}
-\title{Are numeric values nearly equal}
+\title{Check that numeric values are nearly equal}
 \usage{
 are_equal(x, y, tol = sqrt(.Machine$double.eps))
 }
@@ -48,9 +48,9 @@ are_equal(x = 3, y = c(2, 3, 3 + 1e-8, NA, Inf))
 \seealso{
 \code{\link[checkinput:is_natural]{checkinput::is_natural()}} to check for element-wise near-equality to natural
 numbers; \code{\link[=all.equal]{all.equal()}} to check more generally for near-equality;
-\code{\link[=identical]{identical()}} to check for exact equality and \code{\link{Comparison}} to do so using
-binary operators;
-\code{\link[=match]{match()}} and \code{progutils::not_in()} to compare character vectors;
+\code{\link[=identical]{identical()}}, \code{\link[=not_in]{not_in()}} and \code{\link[=match]{match()}} (containing \code{\%in\%} and, from \R
+\verb{4.6.0} onwards, \code{'\%notin\%'}) to check for exact (in)equality, with
+\code{\link{Comparison}} to do so using binary operators;
 \href{https://CRAN.R-project.org/doc/manuals/R-FAQ.html#Why-doesn_0027t-R-think-these-numbers-are-equal_003f}{\R FAQ 7.31}
 for background on numerical equality;
 the vignette \emph{Type coercion} in package \code{checkinput}:

--- a/man/check_case.Rd
+++ b/man/check_case.Rd
@@ -15,9 +15,10 @@ type of signal to be used:
 \code{"message"} to show a \link{message}, or \code{"quiet"} to be quiet.}
 }
 \value{
-Character vector with \link{unique}, \link[=sort]{sorted} values in \code{x} that
-only differ from each other in their case, or \code{character(0)} if no such
-values are present. The return is \link{invisible}.
+A \link[checkinput:all_characters]{character vector} with \link{unique},
+\link[=sort]{sorted} values in \code{x} that only differ from each other in their
+case, or \code{character(0)} if no such values are present, returned
+\link[=invisible]{invisibly}.
 }
 \description{
 Check for values that differ only in their case

--- a/man/create_dir.Rd
+++ b/man/create_dir.Rd
@@ -40,7 +40,7 @@ if it does not yet exist.
 
 \examples{
 # Use a temporary subdirectory to not write in the user's directory
-my_tempdir <- create_tempdir(pattern = "examplecreatedir")
+my_tempdir <- create_tempdir(prefix = "examplecreatedir")
 
 # Create directory 'dir_one' inside this temporary directory
 res_dir_one <- create_dir(dir = fs::path(my_tempdir, "dir_one"),

--- a/man/create_dir.Rd
+++ b/man/create_dir.Rd
@@ -27,16 +27,15 @@ an existing file instead of to an directory.
 Create a directory if it does not yet exist.
 }
 \details{
-The \link[fs:path_abs]{absolute normalised} path is returned such that the
+The \link[fs:path_abs]{absolute, normalised} path is returned such that the
 returned path still works if the \link[=getwd]{working directory} changes. On
-case-insensitive file systems (e.g., Windows and macOS), normalization
-adjusts the case to match case-insensitive names of directories that are
-already present (see the \code{Examples}).
+case-insensitive file systems, normalization also adjusts the case to match
+names of directories that are already present (see the \code{Examples}).
 }
 \section{Side effects}{
 
-The directory indicated by the returned path is \link[=create_dir]{created} if it
-does not yet exist.
+The directory indicated by the returned path is \link[fs:dir_create]{created}
+if it does not yet exist.
 }
 
 \examples{
@@ -72,16 +71,13 @@ rm(my_tempdir, res_dir_one, res_dir_one_v2, res_dir_date, res_dir_ONE)
 
 }
 \seealso{
-\code{\link[checkinput:is_path]{checkinput::is_path()}} to check if a path is valid, and the \verb{Note on paths}
-in its documentation;
+\code{\link[checkinput:is_path]{checkinput::is_path()}} to check if a path is valid, with a \verb{Note on paths}
+and extensive references about file paths and directories;
+\code{\link[=create_tempdir]{create_tempdir()}} for a safe way to create temporary directories;
 \code{\link[=create_file_path]{create_file_path()}} to create a file path and creating the indicated
 directory if it does not yet exist;
-\code{\link[=create_tempdir]{create_tempdir()}} for a safe way to create temporary directories;
-\code{\link[checkinput:is_path]{checkinput::is_path()}} and references there about file paths and directories;
-\code{\link[fs:dir_exists]{fs::dir_exists()}} and \code{\link[fs:dir_create]{fs::dir_create()}} used by this function (and the
-base-equivalent \code{\link[=dir.create]{dir.create()}} of the latter);
-\code{\link[=get_file_path]{get_file_path()}} to check if a file exists and is a unique match to a
-pattern.
+\code{\link[fs:dir_exists]{fs::dir_exists()}} and \code{\link[fs:dir_create]{fs::dir_create()}} (with its base-equivalent
+\code{\link[=dir.create]{dir.create()}}) used by this function;
 
 Other functions to handle paths and directories:
 \code{\link[=create_file_path]{create_file_path()}},

--- a/man/create_file_path.Rd
+++ b/man/create_file_path.Rd
@@ -62,7 +62,7 @@ if it does not yet exist.
 
 \examples{
 # Use a temporary directory to not write in the user's directory
-my_tempdir <- create_tempdir(pattern = "examplecreatefilepath")
+my_tempdir <- create_tempdir(prefix = "examplecreatefilepath")
 
 (create_file_path(filename = "abc.txt", format_stamp = "",
                   dir = my_tempdir, add_date = TRUE))

--- a/man/create_file_path.Rd
+++ b/man/create_file_path.Rd
@@ -7,7 +7,7 @@
 create_file_path(
   filename,
   format_stamp = "\%Y_\%m_\%d_\%H_\%M_\%S",
-  dir = fs::path_wd("output"),
+  dir = fs::path(".", "output"),
   add_date = TRUE
 )
 }
@@ -17,7 +17,8 @@ name, including the file
 extension like \code{.csv} or \code{.txt}. Should adhere to the restrictions described
 in \code{\link[checkinput:is_path]{checkinput::is_path()}}.}
 
-\item{format_stamp}{A character string indicating the \link[=strftime]{format} of
+\item{format_stamp}{\link[checkinput:is_character]{character string} indicating
+the \link[=strftime]{format} of
 the stamp to be added in front of the file name. No stamp is added if
 \code{format_stamp} is an empty string (i.e., \code{""}). The formatted stamp is
 treated as part of the filename, such that the same restrictions apply, see
@@ -34,7 +35,8 @@ default a subdirectory with the current date in the \link[=strftime]{format}
 current date in the \link[=strftime]{format} \code{YYYY_mm_dd}?}
 }
 \value{
-The created file path, returned \link[=invisible]{invisibly}.
+The created \link[fs:path_abs]{absolute normalized} file path, returned
+\link[=invisible]{invisibly}.
 }
 \description{
 Create a file path, creating the indicated directory if it does not yet exist.
@@ -54,7 +56,7 @@ as part of \code{format_stamp} to create precise stamps by truncating seconds to
 }
 \section{Side effects}{
 
-The directory indicated by the returned file path is \link[=create_dir]{created}
+The directory indicated by the returned path is \link[fs:dir_create]{created}
 if it does not yet exist.
 }
 
@@ -85,12 +87,11 @@ rm(my_tempdir)
 
 }
 \seealso{
-\code{\link[checkinput:is_path]{checkinput::is_path()}} to check if a path is valid, and the \verb{Note on paths}
-in its documentation;
+\code{\link[checkinput:is_path]{checkinput::is_path()}} to check if a path is valid, with a \verb{Note on paths}
+and extensive references about file paths and directories;
 \code{\link[=get_file_path]{get_file_path()}} to check if a file exists and is a unique match to a pattern;
-\code{\link[fs:path]{fs::path()}} to construct file paths in a platform-independent way;
-\code{\link[fs:path_abs]{fs::path_abs()}} to create absolute normalised paths;
-\code{\link[=create_dir]{create_dir()}} to create a directory if it does not yet exist
+\code{\link[=create_dir]{create_dir()}} (used by this function) to create a directory if it does not
+yet exist
 
 Other functions to handle paths and directories:
 \code{\link[=create_dir]{create_dir()}},

--- a/man/create_tempdir.Rd
+++ b/man/create_tempdir.Rd
@@ -2,12 +2,12 @@
 % Please edit documentation in R/create_tempdir.R
 \name{create_tempdir}
 \alias{create_tempdir}
-\title{Create a new temporary directory}
+\title{Create a temporary directory}
 \usage{
-create_tempdir(pattern = "tempdir")
+create_tempdir(prefix = "tempdir")
 }
 \arguments{
-\item{pattern}{\link[checkinput:is_character]{character string} with the
+\item{prefix}{\link[checkinput:is_character]{character string} with the
 initial part of the name of the new temporary directory, only containing
 characters that are valid in a \link[checkinput:is_path]{path}.}
 }
@@ -16,11 +16,11 @@ The \link[fs:path_abs]{absolute normalized} path to the created temporary
 directory, returned \link[=invisible]{invisibly}.
 }
 \description{
-Create a new temporary directory that can safely be removed.
+Create a temporary directory that can safely be removed.
 }
 \details{
 The new directory is \link[=dir.create]{created} inside \code{\link[=tempdir]{tempdir()}}. Its
-\link[=tempfile]{name} starts with the string given by \code{pattern} and is followed
+\link[=tempfile]{name} starts with the string given by \code{prefix} and is followed
 by a random string in hex. This random string \strong{might} contain a dot (\code{.})
 such that the directory might appear to have a file extension, see the
 section \code{Source} in \code{help("tempdir")}. An error is thrown if creating the
@@ -39,26 +39,20 @@ empty the temporary directory), the created subdirectories should be
 \link[=unlink]{removed} once they are not needed anymore, see the section
 \verb{Usage in practice} below.
 }
-\section{Side effects}{
-
-The temporary directory indicated by the returned path is
-\link[fs:dir_create]{created} inside \code{\link[=tempdir]{tempdir()}}.
-}
-
 \section{Usage in practice}{
 
 \code{Examples} and \code{tests} should write to a temporary directory that is cleaned
 up afterwards (otherwise \href{https://r-pkgs.org/R-CMD-check.html}{\verb{R cmd check}}
 will issue a \code{Note} about \href{https://contributor.r-project.org/cran-cookbook/code_issues.html#leaving-files-in-the-temporary-directory}{\verb{detritus in the temp directory}}
 and CRAN will not accept your package, see section \verb{Source packages} from the
-\href{https://cran.r-project.org/web/packages/policies.html}{CRAN policies}.
+\href{https://cran.r-project.org/web/packages/policies.html}{CRAN policies}).
 Although \code{\link[=tempdir]{tempdir()}} points to a temporary
 directory, that directory should \strong{not} be removed because other processes
 in \R and \href{https://posit.co/products/open-source/rstudio}{RStudio} also use
 it. Instead, create a temporary subdirectory in \code{\link[=tempdir]{tempdir()}} and afterwards
 clean up by \link[=unlink]{removing} that subdirectory:
 
-\if{html}{\out{<div class="sourceCode">}}\preformatted{my_tempdir <- create_tempdir(pattern = "subtempdir")
+\if{html}{\out{<div class="sourceCode">}}\preformatted{my_tempdir <- create_tempdir(prefix = "subtempdir")
 < do stuff >
 unlink(my_tempdir, recursive = TRUE)
 }\if{html}{\out{</div>}}
@@ -67,6 +61,12 @@ It is good practice to create the complete temporary directory with all
 required files and folders before running any test for the presence or
 absence of particular files or folders: this ensures no spurious matches
 occur if examples or tests are removed or added.
+}
+
+\section{Side effects}{
+
+The directory indicated by the returned path is \link[fs:dir_create]{created}
+if it does not yet exist.
 }
 
 \section{Programming notes}{
@@ -84,14 +84,14 @@ spurious warnings about duplicated file separators.
 \examples{
 tempdir(check = TRUE)
 # Create a directory inside the directory returned by 'tempdir()'
-(my_subtempdir_ex1 <- create_tempdir(pattern = "subtempdir"))
+(my_subtempdir_ex1 <- create_tempdir(prefix = "subtempdir"))
 
-# Using the same 'pattern' again creates another directory
-(my_subtempdir_ex2 <- create_tempdir(pattern = "subtempdir"))
+# Using the same 'prefix' again creates another directory
+(my_subtempdir_ex2 <- create_tempdir(prefix = "subtempdir"))
 
 # It is not possible to create recursive subdirectories
-try(no_subtempdir <- create_tempdir(pattern = "subtempdir/otherdir"))
-try(no_subtempdir <- create_tempdir(pattern = "subtempdir\\\\otherdir"))
+try(no_subtempdir <- create_tempdir(prefix = "subtempdir/otherdir"))
+try(no_subtempdir <- create_tempdir(prefix = "subtempdir\\\\otherdir"))
 
 # Clean up
 unlink(c(my_subtempdir_ex1, my_subtempdir_ex2), recursive = TRUE)
@@ -99,14 +99,14 @@ rm(my_subtempdir_ex1, my_subtempdir_ex2)
 
 }
 \seealso{
-\code{\link[=tempfile]{tempfile()}} used in this function to create the paths for the temporary
-directory;
+\code{\link[checkinput:is_path]{checkinput::is_path()}} to check if a path is valid, with a \verb{Note on paths}
+and extensive references about file paths and directories;
+\code{\link[=create_dir]{create_dir()}} to create a (non-temporary) directory if it does not yet exist;
 \code{\link[=local]{local()}} and
 \href{https://withr.r-lib.org/reference/with_tempfile.html}{withr::local_tempdir()}
 for automated deletion of temporary directories;
-\code{\link[=create_dir]{create_dir()}} to create (non-temporary) directories;
-\code{\link[checkinput:is_path]{checkinput::is_path()}} to check if a path is valid, with the \verb{Note on paths}
-in its documentation.
+\code{\link[=tempfile]{tempfile()}} used in this function to create the paths for the temporary
+directory;
 
 Other functions to handle paths and directories:
 \code{\link[=create_dir]{create_dir()}},

--- a/man/get_file_path.Rd
+++ b/man/get_file_path.Rd
@@ -14,7 +14,8 @@ get_file_path(dir = ".", pattern, ignore_case = TRUE, quietly = FALSE)
 \link[base:regex]{regular expression}
 used to select names of files that are present in \code{dir}.}
 
-\item{ignore_case}{\code{TRUE} or \code{FALSE}: use case-insensitive pattern matching?}
+\item{ignore_case}{\code{TRUE} or \code{FALSE}: use \link[=tolower]{case-insensitive}
+pattern matching?}
 
 \item{quietly}{\code{TRUE} or \code{FALSE}: suppress the message with the found file
 name?}
@@ -36,7 +37,8 @@ If \code{ignore_case} is \code{FALSE} and no case-sensitive match is found, the 
 message indicates if any case-insensitive match is present.
 
 In contrast to the default of \code{\link[=list.files]{list.files()}}, \code{get_file_path()} also finds
-'hidden' files, i.e., files with names that start with a dot.
+'hidden' files, i.e., files with names that start with a dot, and excludes
+directories.
 
 Paths will be \link[fs:path_abs]{normalized} to ensure they still work if the
 \link[=getwd]{working directory} changes.
@@ -77,16 +79,15 @@ rm(my_tempfiles)
 
 }
 \seealso{
-\code{\link[checkinput:is_path]{checkinput::is_path()}} to check if a path is valid, and the \verb{Note on paths}
-in its documentation;
-\code{\link[=create_dir]{create_dir()}} to create a directory if does not yet exist;
+\code{\link[checkinput:is_path]{checkinput::is_path()}} to check if a path is valid, with a \verb{Note on paths}
+and extensive references about file paths and directories;
+\code{\link[=create_file_path]{create_file_path()}} to create a file path and creating the indicated
+directory if it does not yet exist;
 \code{\link[fs:file_exists]{fs::file_exists()}} and \code{\link[=list.files]{list.files()}} (which \strong{includes} directories) to
 check for existence of files without checking they are a unique match to a
 pattern;
 \code{\link[=file.info]{file.info()}} and \code{\link[=file.access]{file.access()}} to extract information about files or
-directories;
-\code{\link[fs:path]{fs::path()}} to construct file paths in a platform-independent way;
-\code{\link[fs:path_abs]{fs::path_abs()}} to create absolute paths.
+directories
 
 Other functions to handle paths and directories:
 \code{\link[=create_dir]{create_dir()}},

--- a/man/get_file_path.Rd
+++ b/man/get_file_path.Rd
@@ -45,7 +45,7 @@ Paths will be \link[fs:path_abs]{normalized} to ensure they still work if the
 }
 \examples{
 # Create files in a temporary directory so we know what is present.
-my_tempdir <- create_tempdir(pattern = "examplegetfilepath")
+my_tempdir <- create_tempdir(prefix = "examplegetfilepath")
 my_tempfiles <- fs::path_abs(
   fs::path(my_tempdir, paste0(c("some_filename", "another_filename"), ".txt"))
 )

--- a/man/not_in.Rd
+++ b/man/not_in.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/not_in.R
 \name{not_in}
 \alias{not_in}
-\title{Are values absent}
+\title{Check that values are absent}
 \usage{
 not_in(x, table, value = TRUE)
 }
@@ -80,8 +80,9 @@ not_in(c(x = "c", y = "b", z = "a"), c(a = "a", b = "b"))
 \seealso{
 \code{\link[=setdiff]{setdiff()}} for a similar function which removes duplicates;
 \code{\link[=are_equal]{are_equal()}} to match numeric input using a tolerance;
-\code{\link[=match]{match()}} containing \code{\%in\%}, and, from \R \verb{4.6.0} onwards, \code{'\%notin\%'}, on
-which this function is based.
+\code{\link[=identical]{identical()}}, \code{\link[=not_in]{not_in()}} and \code{\link[=match]{match()}} (containing \code{\%in\%} and, from \R
+\verb{4.6.0} onwards, \code{'\%notin\%'}) to check for exact (in)equality, with
+\code{\link{Comparison}} to do so using binary operators
 
 Other functions to check equality:
 \code{\link[=are_equal]{are_equal()}},

--- a/man/reorder_cols.Rd
+++ b/man/reorder_cols.Rd
@@ -11,7 +11,7 @@ reorder_cols(x, new_order)
 syntactically valid names, see \code{\link[checkinput:all_names]{checkinput::all_names()}}.}
 
 \item{new_order}{Character vector with a length larger than zero containing
-unique names in the new order of the columns.}
+unique names in the new order.}
 }
 \value{
 \code{x} with reordered columns.
@@ -37,7 +37,9 @@ reorder_cols(x = test_df, new_order = c("b", "a", "d"))
 
 }
 \seealso{
-\code{\link[=order]{order()}}, \code{\link[=sort]{sort()}}
+\code{\link[=order]{order()}}; \code{\link[=sort]{sort()}};
+\code{\link[=append]{append()}} which, despite its name, can insert values into a vector at any
+place
 
 Other functions to modify sorting order:
 \code{\link[=reorder_levels]{reorder_levels()}}

--- a/man/reorder_levels.Rd
+++ b/man/reorder_levels.Rd
@@ -11,15 +11,15 @@ reorder_levels(x, new_order, warn_drop_order = TRUE)
 vector to be converted to a factor with levels ordered as \code{new_order}. Should
 have length larger than zero.}
 
-\item{new_order}{Unique character vector with a length larger than zero
-indicating the new order of the factor levels.}
+\item{new_order}{Character vector with a length larger than zero containing
+unique names in the new order.}
 
 \item{warn_drop_order}{\code{TRUE} or \code{FALSE}: warn if values of \code{new_order} are
 dropped because they are not present in \code{x}?}
 }
 \value{
-\code{x} after converting it to a \link{factor} with its levels reordered to
-\code{new_order}, dropping values in \code{new_order} not present in \code{x}.
+\code{x} after converting it to a \link{factor} with levels reordered to
+\code{new_order}, dropping values in \code{new_order} that are not present in \code{x}.
 }
 \description{
 Reorder factor levels
@@ -58,7 +58,8 @@ orig
 
 }
 \seealso{
-\code{\link[stats:relevel]{stats::relevel()}} to assign one reference level to a factor
+\code{\link[stats:relevel]{stats::relevel()}} to assign one reference level to a factor;
+\code{\link[=order]{order()}}; \code{\link[=sort]{sort()}}
 
 Other functions to convert types:
 \code{\link[=as.numeric_safe]{as.numeric_safe()}},

--- a/man/replace_vals.Rd
+++ b/man/replace_vals.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/replace_vals.R
 \name{replace_vals}
 \alias{replace_vals}
-\title{Replace character values or factor levels}
+\title{Replace values}
 \usage{
 replace_vals(
   x,
@@ -24,7 +24,7 @@ replace_vals(
 \item{old}{Character vector with values to be replaced. Should be \link{unique}
 and not contain the value \code{new}, otherwise an error is thrown.}
 
-\item{new}{Character string of length one with the new value.}
+\item{new}{Character string with the new value.}
 
 \item{ignore_case}{\code{TRUE} or \code{FALSE}: ignore \link[=tolower]{case} when looking for
 \code{old}? See \code{Details}.}
@@ -32,7 +32,8 @@ and not contain the value \code{new}, otherwise an error is thrown.}
 \item{allow_multiple}{\code{TRUE} or \code{FALSE}: allow multiple values of \code{old} to
 match \code{x}? See \code{Details}.}
 
-\item{warn_absent}{\code{TRUE} or \code{FALSE}: warn if \code{old} nor \code{new} are found in
+\item{warn_absent}{\code{TRUE} or \code{FALSE}: warn if neither \code{old} nor \code{new} is
+found in
 \code{x}? It is silently assumed replacement is not necessary anymore if \code{new} is
 found.}
 
@@ -46,15 +47,15 @@ influenced by argument \code{signal_old_ignore_case}.}
 \code{ignore_case} is \code{TRUE}? If \code{FALSE}, no signal is emitted if \code{ignore_case} is
 \code{TRUE}.}
 
-\item{quiet}{\code{TRUE} or \code{FALSE}: suppress printing the message with the values
-that have been replaced?}
+\item{quiet}{\code{TRUE} or \code{FALSE}: suppress the message indicating which values
+have been replaced?}
 }
 \value{
 \code{x} with the requested replacements. Factor levels are \strong{not} reordered
 after the replacement.
 }
 \description{
-Replace character values or factor levels
+Replace values, also handling factor levels
 }
 \details{
 Values in \code{x} that \link[=check_case]{only differ} from \code{new} in their case are

--- a/man/signal_text.Rd
+++ b/man/signal_text.Rd
@@ -11,7 +11,8 @@ signal_text(
 )
 }
 \arguments{
-\item{text}{Vector with text to be signalled, coerced to character by
+\item{text}{\link[checkinput:all_characters]{character vector} with text to be
+signalled, coerced to a \link[checkinput:is_character]{character string} by
 \code{\link[=vect_to_char]{vect_to_char()}}.}
 
 \item{signal}{\link[checkinput:is_character]{character string} indicating the
@@ -23,8 +24,9 @@ type of signal to be used:
 message. Ignored if it is \code{character(0)}.}
 }
 \value{
-\code{text}, with a phrase indicating the origin of the signal if \code{origin} is not
-\code{NULL}, returned \link[=invisible]{invisibly}.
+\link[checkinput:is_character]{character string} containing \code{text}, with a
+phrase indicating the origin of the signal if \code{origin} is not \code{NULL},
+returned \link[=invisible]{invisibly}.
 }
 \description{
 Signal a text to the user through an error, warning, or message.
@@ -88,8 +90,6 @@ grepl(pattern = "negative", x = attr(res_positive, "text_signal"),
 
 }
 \seealso{
-\code{\link[=wrap_text]{wrap_text()}}
-
 Other functions to modify character vectors:
 \code{\link[=as.numeric_safe]{as.numeric_safe()}},
 \code{\link{reexports}},

--- a/man/unpaste_unquote.Rd
+++ b/man/unpaste_unquote.Rd
@@ -9,17 +9,18 @@ unpaste_unquote(x, collapse = c(", ", "; "), quotemarks = c("'", "\\""))
 \arguments{
 \item{x}{a \link[checkinput:is_character]{character string}.}
 
-\item{collapse}{\link[checkinput:all_characters]{character string} with
+\item{collapse}{\link[checkinput:all_characters]{character vector} with
 elements that were used to collapse
 values when \code{x} was created, and are now used to \link[=strsplit]{split} \code{x} on.
 Can be \code{character(0)} to leave \code{x} as a character string.}
 
-\item{quotemarks}{Character vector with quotation marks to be removed from
-\code{x}. Can be \code{character(0)} to not remove any quotation marks.}
+\item{quotemarks}{\link[checkinput:all_characters]{character vector} with
+quotation marks to be removed from \code{x}. Can be \code{character(0)} to not remove
+any quotation marks.}
 }
 \value{
-\code{x} without the quotation marks indicated by \code{quotemarks}, split into a
-vector on \code{collapse}.
+\code{x} without the quotation marks in \code{quotemarks}, split into a vector on the
+string in \code{collapse}.
 }
 \description{
 Create a character vector from a string with quotation marks

--- a/man/vect_to_char.Rd
+++ b/man/vect_to_char.Rd
@@ -39,11 +39,11 @@ A character vector or character string with the names and values in \code{x}, wi
 values of numeric \code{x} rounded to \code{signif}
 \link[=signif]{significant} digits, wrapped to \code{width} characters.
 
-If \code{collapse} is \code{NULL}, a \link[checkinput:all_characters]{character \strong{vector}}
+If \code{collapse} is \code{NULL}, a \link[checkinput:all_characters]{character vector}
 with the same elements as \code{x}
 is returned, wrapping on a per-element basis. If \code{collapse} is not \code{NULL},
 the name-value pairs are separated by \code{collapse}, thus returning a
-\link[checkinput:is_character]{character \strong{string}}.
+\link[checkinput:is_character]{character string}.
 
 See \code{Details} on handling of some special values.
 }

--- a/man/vect_to_char.Rd
+++ b/man/vect_to_char.Rd
@@ -35,13 +35,15 @@ element of a character vector.}
 by blank characters?}
 }
 \value{
-The names and values in \code{x}, with values of numeric \code{x} rounded to \code{signif}
+A character vector or character string with the names and values in \code{x}, with
+values of numeric \code{x} rounded to \code{signif}
 \link[=signif]{significant} digits, wrapped to \code{width} characters.
 
-If \code{collapse} is \code{NULL}, a character \strong{vector} with the same elements as \code{x}
+If \code{collapse} is \code{NULL}, a \link[checkinput:all_characters]{character \strong{vector}}
+with the same elements as \code{x}
 is returned, wrapping on a per-element basis. If \code{collapse} is not \code{NULL},
-the name-value pairs are separated by \code{collapse}, thus returning a character
-\strong{string}.
+the name-value pairs are separated by \code{collapse}, thus returning a
+\link[checkinput:is_character]{character \strong{string}}.
 
 See \code{Details} on handling of some special values.
 }
@@ -101,7 +103,8 @@ paste0(vect_to_char(c(table(x)), sep = " (", collapse =  "), "), ")")
 
 }
 \seealso{
-\code{\link[=toString]{toString()}} which can be used if names of \code{x} can be removed;
+\code{\link[=toString]{toString()}} which is shorthand for \code{paste(x, collapse = ", ")} and can be
+used instead of \code{vect_to_char()} if names of \code{x} can be removed;
 \code{vignette("type_coercion", package = "checkinput")} and
 \code{help("is_zerolength", package = "checkinput")} for a discussion of some
 issues with type conversion and zero-length input when \link[=c]{combining}

--- a/man/wrap_text.Rd
+++ b/man/wrap_text.Rd
@@ -17,7 +17,8 @@ after wrapping. Can be \code{Inf} to not wrap text.}
 by blank characters?}
 }
 \value{
-A string containing \code{x} wrapped to a maximum of \code{width} characters, with
+A \link[checkinput:is_character]{character string} containing \code{x} wrapped to a
+maximum of \code{width} characters, with
 newlines inserted at blank characters. A warning is issued if the width of a
 fragment in the output exceeds \code{width}: this occurs if a stretch of
 characters longer than \code{width} occurs without a blank character to wrap at.
@@ -43,7 +44,6 @@ Leading and trailing newlines are collapsed into a single blank character if
 The call \code{wrap_text(x, width)} can be replaced by
 \code{paste0(strwrap(x, width + 1L), collapse = "\\n")} if \code{x} has length one and
 \code{ignore_newlines} is \code{TRUE}.
-
 
 Using \code{wrap_text()} on \code{x} of variable length, e.g., in the text of warnings
 that report a file path or a user-provided variable name, makes the location
@@ -72,7 +72,7 @@ cat(wrap_text(example_text,
 
 }
 \seealso{
-\code{\link[=cat]{cat()}} \code{\link[=paste]{paste()}} \code{\link[=strwrap]{strwrap()}}
+\code{\link[=cat]{cat()}}; \code{\link[=paste]{paste()}}; \code{\link[=strwrap]{strwrap()}}
 
 Other functions to modify character vectors:
 \code{\link[=as.numeric_safe]{as.numeric_safe()}},


### PR DESCRIPTION
### Breaking changes
- `create_tempdir()`: rename argument `pattern` to `prefix`.
- Dependency `fs`: require minimum version of `1.3.0` to use argument `recurse`.
- Remove suggested dependency `tools` that has been obsolete since replacing `file_path_no_ext()` by `fs::path_ext_remove()` and `file_path_ext()` by `fs::path_ext()` in `progutils 0.3.0`.