### PR TITLE
progutils 0.13.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: progutils
 Title: Programming Utilities
-Version: 0.12.0
+Version: 0.13.0
 Authors@R: 
     person("Jesse", "Alderliesten", , "jessealderliesten@hotmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-1132-4310"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# progutils 0.13.0
+
+### Breaking changes
+- `wrap_text()`: gain argument `warn_length` with default `FALSE` to not warn if
+  a text fragment exceeds `width`. This prevents spurious warnings when
+  `wrap_text()` is called from other functions but differs from to the previous
+  implicit `warn_length = TRUE`.
+
+
 # progutils 0.12.0
 
 ### Breaking changes

--- a/R/check_case.R
+++ b/R/check_case.R
@@ -21,7 +21,7 @@
 #' @family functions to check equality
 #'
 #' @seealso
-#' [tolower()] and [toupper()] to **change** case.
+#' [tolower()] and [toupper()] to change case.
 #'
 #' @examples
 #' x <- c("Ee", "Ee", "LL", "Ll")

--- a/R/create_file_path.R
+++ b/R/create_file_path.R
@@ -31,6 +31,10 @@
 #' as part of `format_stamp` to create precise stamps by truncating seconds to
 #' `0 <= n <= 6` decimal places, see [strftime()] for details.
 #'
+#' The file is **not** created by `create_file_path()`, use
+#' `fs::file_create(create_file_path(filename = "abc.txt", ...))` or
+#' `file.create(create_file_path(filename = "abc.txt", ...))` to do so.
+#'
 #' @inheritSection create_dir Side effects
 #'
 #' @seealso

--- a/R/create_tempdir.R
+++ b/R/create_tempdir.R
@@ -9,7 +9,7 @@
 #' @details
 #' The new directory is [created][dir.create()] inside [tempdir()]. Its
 #' [name][tempfile()] starts with the string given by `prefix` and is followed
-#' by a random string in hex. This random string **might** contain a dot (`.`)
+#' by a random string. This random string **might** contain a dot (`.`)
 #' such that the directory might appear to have a file extension, see the
 #' section `Source` in `help("tempdir")`. An error is thrown if creating the
 #' directory fails.
@@ -66,6 +66,9 @@
 #' [local()] and
 #' [withr::local_tempdir()](https://withr.r-lib.org/reference/with_tempfile.html)
 #' for automated deletion of temporary directories;
+#' [withr::withr::local_dir()](https://withr.r-lib.org/reference/with_dir.html)
+#' and [usethis::local_project()](https://usethis.r-lib.org/reference/proj_utils.html)
+#' to change the working directory to a temporary directory;
 #' [tempfile()] used in this function to create the paths for the temporary
 #' directory;
 #'

--- a/R/wrap_text.R
+++ b/R/wrap_text.R
@@ -8,6 +8,7 @@
 #' after wrapping. Can be `Inf` to not wrap text.
 #' @param ignore_newlines `TRUE` or `FALSE`: should newlines in `x` be replaced
 #' by blank characters?
+#' @param warn_length `TRUE` or `FALSE`: warn if a fragment exceeds `width`?
 #'
 #' @details
 #' `character(0)` input to `x` is returned unchanged, with a warning.
@@ -24,10 +25,10 @@
 #'
 #' @returns
 #' A [character string][checkinput::is_character()] containing `x` wrapped to a
-#' maximum of `width` characters, with
-#' newlines inserted at blank characters. A warning is issued if the width of a
-#' fragment in the output exceeds `width`: this occurs if a stretch of
-#' characters longer than `width` occurs without a blank character to wrap at.
+#' maximum of `width` characters, with newlines inserted at blank characters. A
+#' warning is issued if `warn_length` is `TRUE` and the width of a fragment in
+#' the output exceeds `width`: this occurs if a stretch of characters longer
+#' than `width` occurs without a blank character to wrap at.
 #'
 #' @section Programming notes:
 #' The call `wrap_text(x, width)` can be replaced by
@@ -62,10 +63,11 @@
 #'               width = 20, ignore_newlines = FALSE))
 #'
 #' @export
-wrap_text <- function(x, width = 80L, ignore_newlines = TRUE) {
+wrap_text <- function(x, width = 80L, ignore_newlines = TRUE,
+                      warn_length = FALSE) {
   stopifnot(
     checkinput::all_characters(x, allow_empty = TRUE, allow_zerolength = TRUE),
-    checkinput::is_logical(ignore_newlines))
+    checkinput::is_logical(ignore_newlines), checkinput::is_logical(warn_length))
   if(!is.infinite(width)) {
     width <- checkinput::make_natural(width)
   }
@@ -117,7 +119,7 @@ wrap_text <- function(x, width = 80L, ignore_newlines = TRUE) {
   }
 
   bool_too_long <- nchar(x) > width
-  if(any(bool_too_long)) {
+  if(warn_length && any(bool_too_long)) {
     warning("Width of ", length(which(bool_too_long)), " text fragments (",
             toString(nchar(x[bool_too_long])), " characters) exceeds 'width' (",
             width, " characters)")

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ License](LICENSE.md).
     To cite package 'progutils' in publications use:
 
       Alderliesten J (2026). _progutils: Programming Utilities_. R package
-      version 0.12.0, <https://github.com/JesseAlderliesten/progutils>.
+      version 0.13.0, <https://github.com/JesseAlderliesten/progutils>.
 
     A BibTeX entry for LaTeX users is
 
@@ -115,7 +115,7 @@ License](LICENSE.md).
         title = {progutils: Programming Utilities},
         author = {Jesse Alderliesten},
         year = {2026},
-        note = {R package version 0.12.0},
+        note = {R package version 0.13.0},
         url = {https://github.com/JesseAlderliesten/progutils},
       }
 

--- a/inst/tinytest/test_wrap_text.R
+++ b/inst/tinytest/test_wrap_text.R
@@ -37,13 +37,19 @@ expect_identical(
 ##### Note #####
 expect_warning(
   expect_identical(
-    wrap_text(x = paste0(x_text, x_text_nospace), width = 15),
+    wrap_text(x = paste0(x_text, x_text_nospace), width = 15, warn_length = TRUE),
     paste0("A piece of text\nthat you want\nto wrap over\nmultiple\nlines",
            x_text_nospace)),
   pattern = paste0("Width of 1 text fragments (40 characters) exceeds 'width'",
                    " (15 characters)"),
   strict = TRUE, fixed = TRUE)
 
+expect_silent(
+  expect_identical(
+    wrap_text(x = paste0(x_text, x_text_nospace), width = 15, warn_length = FALSE),
+    paste0("A piece of text\nthat you want\nto wrap over\nmultiple\nlines",
+           x_text_nospace))
+  )
 
 #### Tests ####
 expect_silent(expect_identical(wrap_text(x = "", width = 1L), ""))
@@ -192,28 +198,36 @@ expect_identical(
 
 ##### Fragments longer than width #####
 expect_warning(expect_identical(
-  wrap_text(x = "12345678911", width = 10L),
+  wrap_text(x = "12345678911", width = 10L, warn_length = TRUE),
   "12345678911"),
   pattern = warn_too_long, strict = TRUE, fixed = TRUE)
 
+expect_silent(expect_identical(
+  wrap_text(x = "12345678911", width = 10L, warn_length = FALSE),
+  "12345678911"))
+
 expect_warning(expect_identical(
-  wrap_text(x = "12345678911 XXX YYY ZZZZZZ", width = 10L),
+  wrap_text(x = "12345678911 XXX YYY ZZZZZZ", width = 10L, warn_length = TRUE),
   "12345678911\nXXX YYY\nZZZZZZ"),
   pattern = warn_too_long, strict = TRUE, fixed = TRUE)
 
+expect_silent(expect_identical(
+  wrap_text(x = "12345678911 XXX YYY ZZZZZZ", width = 10L, warn_length = FALSE),
+  "12345678911\nXXX YYY\nZZZZZZ"))
+
 expect_warning(expect_identical(
-  wrap_text(x = "XXX YYY 12345678911 ZZZZZZ", width = 10L),
+  wrap_text(x = "XXX YYY 12345678911 ZZZZZZ", width = 10L, warn_length = TRUE),
   "XXX YYY\n12345678911\nZZZZZZ"),
   pattern = warn_too_long, strict = TRUE, fixed = TRUE)
 
 expect_warning(expect_identical(
-  wrap_text(x = "XXX YYY ZZZZZZ 12345678911", width = 10L),
+  wrap_text(x = "XXX YYY ZZZZZZ 12345678911", width = 10L, warn_length = TRUE),
   "XXX YYY\nZZZZZZ\n12345678911"),
   pattern = warn_too_long, strict = TRUE, fixed = TRUE)
 
 expect_warning(expect_identical(
   wrap_text(x = "123456789111315 XXX YYY 1234567891113 ZZZZZZ 12345678911",
-            width = 10L),
+            width = 10L, warn_length = TRUE),
   "123456789111315\nXXX YYY\n1234567891113\nZZZZZZ\n12345678911"),
   pattern = paste0("Width of 3 text fragments (15, 13, 11 characters) exceeds",
                    " 'width' (10 characters)"), strict = TRUE, fixed = TRUE)
@@ -258,8 +272,10 @@ expect_error(
   wrap_text(x = x, width = 10.1),
   pattern = "is_natural(width) is not TRUE", fixed = TRUE)
 
-expect_warning(expect_identical(
-  wrap_text(x = x, width = 1L), "123\n567\n911\n141\n719\n123\n262\n931"),
+expect_warning(
+  expect_identical(
+    wrap_text(x = x, width = 1L, warn_length = TRUE),
+    "123\n567\n911\n141\n719\n123\n262\n931"),
   pattern = paste0("Width of 8 text fragments (3, 3, 3, 3, 3, 3, 3, 3 characters)",
                    " exceeds 'width' (1 characters)"), strict = TRUE, fixed = TRUE)
 

--- a/man/check_case.Rd
+++ b/man/check_case.Rd
@@ -41,7 +41,7 @@ check_case(x = x, signal = "warning")
 
 }
 \seealso{
-\code{\link[=tolower]{tolower()}} and \code{\link[=toupper]{toupper()}} to \strong{change} case.
+\code{\link[=tolower]{tolower()}} and \code{\link[=toupper]{toupper()}} to change case.
 
 Other functions to check equality:
 \code{\link[=are_equal]{are_equal()}},

--- a/man/create_file_path.Rd
+++ b/man/create_file_path.Rd
@@ -53,6 +53,10 @@ A warning is issued if the \strong{file} indicated by the returned path already
 exists. To prevent this when creating files in quick succession, use \code{"\%OSn"}
 as part of \code{format_stamp} to create precise stamps by truncating seconds to
 \verb{0 <= n <= 6} decimal places, see \code{\link[=strftime]{strftime()}} for details.
+
+The file is \strong{not} created by \code{create_file_path()}, use
+\code{fs::file_create(create_file_path(filename = "abc.txt", ...))} or
+\code{file.create(create_file_path(filename = "abc.txt", ...))} to do so.
 }
 \section{Side effects}{
 

--- a/man/create_tempdir.Rd
+++ b/man/create_tempdir.Rd
@@ -21,7 +21,7 @@ Create a temporary directory that can safely be removed.
 \details{
 The new directory is \link[=dir.create]{created} inside \code{\link[=tempdir]{tempdir()}}. Its
 \link[=tempfile]{name} starts with the string given by \code{prefix} and is followed
-by a random string in hex. This random string \strong{might} contain a dot (\code{.})
+by a random string. This random string \strong{might} contain a dot (\code{.})
 such that the directory might appear to have a file extension, see the
 section \code{Source} in \code{help("tempdir")}. An error is thrown if creating the
 directory fails.
@@ -105,6 +105,9 @@ and extensive references about file paths and directories;
 \code{\link[=local]{local()}} and
 \href{https://withr.r-lib.org/reference/with_tempfile.html}{withr::local_tempdir()}
 for automated deletion of temporary directories;
+\href{https://withr.r-lib.org/reference/with_dir.html}{withr::withr::local_dir()}
+and \href{https://usethis.r-lib.org/reference/proj_utils.html}{usethis::local_project()}
+to change the working directory to a temporary directory;
 \code{\link[=tempfile]{tempfile()}} used in this function to create the paths for the temporary
 directory;
 

--- a/man/wrap_text.Rd
+++ b/man/wrap_text.Rd
@@ -4,7 +4,7 @@
 \alias{wrap_text}
 \title{Wrap text}
 \usage{
-wrap_text(x, width = 80L, ignore_newlines = TRUE)
+wrap_text(x, width = 80L, ignore_newlines = TRUE, warn_length = FALSE)
 }
 \arguments{
 \item{x}{\link[checkinput:all_characters]{character vector} to be wrapped.}
@@ -15,13 +15,15 @@ after wrapping. Can be \code{Inf} to not wrap text.}
 
 \item{ignore_newlines}{\code{TRUE} or \code{FALSE}: should newlines in \code{x} be replaced
 by blank characters?}
+
+\item{warn_length}{\code{TRUE} or \code{FALSE}: warn if a fragment exceeds \code{width}?}
 }
 \value{
 A \link[checkinput:is_character]{character string} containing \code{x} wrapped to a
-maximum of \code{width} characters, with
-newlines inserted at blank characters. A warning is issued if the width of a
-fragment in the output exceeds \code{width}: this occurs if a stretch of
-characters longer than \code{width} occurs without a blank character to wrap at.
+maximum of \code{width} characters, with newlines inserted at blank characters. A
+warning is issued if \code{warn_length} is \code{TRUE} and the width of a fragment in
+the output exceeds \code{width}: this occurs if a stretch of characters longer
+than \code{width} occurs without a blank character to wrap at.
 }
 \description{
 Wrap text at blank characters to achieve a maximum line width.


### PR DESCRIPTION
### Breaking changes
- `wrap_text()`: gain argument `warn_length` with default `FALSE` to not warn if a text fragment exceeds `width`. This prevents spurious warnings when `wrap_text()` is called from other functions but differs from to the previous implicit `warn_length = TRUE`.